### PR TITLE
Fix jvmTarget deprecation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 @file:Suppress("UnstableApiUsage")
 
 import org.gradle.api.JavaVersion.VERSION_17
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
 import org.jlleitschuh.gradle.ktlint.reporter.ReporterType.HTML
 import java.io.FileInputStream
 import java.nio.file.Paths
@@ -50,10 +51,6 @@ android {
   compileOptions {
     sourceCompatibility = jvmVersion
     targetCompatibility = jvmVersion
-  }
-
-  kotlinOptions {
-    jvmTarget = jvmVersion.toString()
   }
 
   buildFeatures {
@@ -166,6 +163,12 @@ ksp {
   arg("dagger.formatGeneratedSource", "disabled")
   arg("dagger.fastInit", "enabled")
   arg("dagger.experimentalDaggerErrorMessages", "enabled")
+}
+
+kotlin {
+  compilerOptions {
+    jvmTarget.set(JVM_17)
+  }
 }
 
 dependencies {

--- a/test-resources/build.gradle.kts
+++ b/test-resources/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.gradle.api.JavaVersion.VERSION_17
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
 import java.net.URL
 
 plugins {
@@ -26,10 +27,6 @@ android {
     targetCompatibility = jvmVersion
   }
 
-  kotlinOptions {
-    jvmTarget = jvmVersion.toString()
-  }
-
   lint {
     abortOnError = true
     checkAllWarnings = true
@@ -52,6 +49,12 @@ android {
         "**/*.xml",
         "**/*.properties",
       )
+  }
+}
+
+kotlin {
+  compilerOptions {
+    jvmTarget.set(JVM_17)
   }
 }
 


### PR DESCRIPTION
## Summary
- use compilerOptions DSL for Kotlin jvmTarget configuration

## Testing
- `./gradlew testDebug --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862e8970d30832a99ed77c79e910443