### PR TITLE
Use val properties for GifImageInfo

### DIFF
--- a/app/src/main/java/com/burrowsapps/gif/search/ui/giflist/GifImageInfo.kt
+++ b/app/src/main/java/com/burrowsapps/gif/search/ui/giflist/GifImageInfo.kt
@@ -7,8 +7,8 @@ import androidx.compose.runtime.Immutable
  */
 @Immutable
 internal data class GifImageInfo(
-  var tinyGifUrl: String = "",
-  var tinyGifPreviewUrl: String = "",
-  var gifUrl: String = "",
-  var gifPreviewUrl: String = "",
+  val tinyGifUrl: String = "",
+  val tinyGifPreviewUrl: String = "",
+  val gifUrl: String = "",
+  val gifPreviewUrl: String = "",
 )


### PR DESCRIPTION
## Summary
- make `GifImageInfo` immutable by using `val` for its fields

## Testing
- `./gradlew testDebug` *(fails: Android SDK licenses not accepted)*

------
https://chatgpt.com/codex/tasks/task_e_688551fed958832abd068ca2a026537d