### PR TITLE
Update Gradle wrapper to v9

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
+import com.github.benmanes.gradle.versions.updates.resolutionstrategy.ComponentSelectionWithCurrent
 import org.gradle.api.JavaVersion.VERSION_17
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
 import org.gradle.api.tasks.testing.logging.TestLogEvent.FAILED
@@ -43,20 +44,20 @@ allprojects {
       return isStable.not()
     }
 
-    resolutionStrategy {
-      componentSelection {
-        all {
-          when (candidate.group) {
-            // Allow non-stable versions for these groups
-            "com.android.application", "org.jetbrains.kotlin" -> {}
-            else -> {
-              if (isNonStable(candidate.version) && !isNonStable(currentVersion)) {
-                reject("Release candidate")
+      resolutionStrategy {
+        componentSelection {
+          all { selection: ComponentSelectionWithCurrent ->
+            when (selection.candidate.group) {
+              // Allow non-stable versions for these groups
+              "com.android.application", "org.jetbrains.kotlin" -> {}
+              else -> {
+                if (isNonStable(selection.candidate.version) && !isNonStable(selection.currentVersion)) {
+                  selection.reject("Release candidate")
+                }
               }
             }
           }
         }
-      }
     }
   }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- update Gradle wrapper to use v9.0.0
- fix dependencyUpdates rule to compile with Gradle 9

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon` *(fails: Android SDK license not accepted)*

------
https://chatgpt.com/codex/tasks/task_e_688be6695f9c832aa764a56eef818ddc