### PR TITLE
refactor: replace deprecated URL usage

### DIFF
--- a/test-resources/build.gradle.kts
+++ b/test-resources/build.gradle.kts
@@ -1,6 +1,6 @@
 import org.gradle.api.JavaVersion.VERSION_17
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
-import java.net.URL
+import java.net.URI
 
 plugins {
   alias(libs.plugins.android.library)
@@ -78,7 +78,8 @@ tasks.register("updateTestFiles") {
 
     testData.forEach { (file, url) ->
       val jsonContent =
-        URL(url)
+        URI(url)
+          .toURL()
           .readText()
           // Point our mock JSON to point to local OkHTTP Mock server
           .replace("media.tenor.com", "localhost:8080")


### PR DESCRIPTION
## Summary
- avoid deprecated `URL(String)` constructor in test-resources module by using `URI`

## Testing
- `./gradlew :test-resources:build` *(fails: Could not determine the dependencies of task ':test-resources:extractDebugAnnotations'. Failed to install the following Android SDK packages as some licences have not been accepted)*

------
https://chatgpt.com/codex/tasks/task_e_68acb4e87c0c832aa6144b432fa7638e