### PR TITLE
make ci build faster

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,14 +11,14 @@ env:
   JAVA_VERSION: 25
   ANDROID_API_LEVEL: 36
 
+permissions:
+  checks: write
+  pull-requests: write
+
 jobs:
   checks:
     name: Checks
     runs-on: ubuntu-latest
-
-    permissions:
-      checks: write
-      pull-requests: write
 
     steps:
       - name: Checkout Project
@@ -75,10 +75,6 @@ jobs:
   instrumentation:
     name: Instrumentation Tests
     runs-on: ubuntu-latest
-
-    permissions:
-      checks: write
-      pull-requests: write
 
     steps:
       - name: Checkout Project

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,13 +8,12 @@ on:
     types: [ opened, labeled, unlabeled, synchronize ]
 
 env:
-  GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false -Dkotlin.incremental=false"
   JAVA_VERSION: 25
   ANDROID_API_LEVEL: 36
 
 jobs:
-  build:
-    name: Build
+  checks:
+    name: Checks
     runs-on: ubuntu-latest
 
     permissions:
@@ -25,31 +24,27 @@ jobs:
       - name: Checkout Project
         uses: actions/checkout@v6.0.3
 
-      - name: Validate Gradle Wrapper
-        uses: gradle/actions/wrapper-validation@v6
-
       - name: Configure JDK ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v5.2.0
         with:
           distribution: temurin
           java-version: ${{ env.JAVA_VERSION }}
-          cache: gradle
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
-      - run: ./gradlew --version
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
-      - name: Run Ktlint Check On All Sources
-        run: ./gradlew ktlintCheck -s
+      - name: Cache Robolectric android-all jars
+        uses: actions/cache@v5.0.5
+        with:
+          path: ~/.m2/repository/org/robolectric
+          key: robolectric-${{ hashFiles('gradle/libs.versions.toml') }}
+          restore-keys: |
+            robolectric-
 
-      - name: Build Debug APK
-        run: ./gradlew assembleDebug -s
-
-      - name: Run Debug Lint Checks
-        run: ./gradlew lintDebug -s
-
-      - name: Run Debug Unit Tests
-        run: ./gradlew testDebug -s
+      - name: Ktlint, Assemble, Lint, Unit Tests
+        run: ./gradlew ktlintCheck assembleDebug lintDebug testDebug -s --continue
 
       - name: Publish Unit Test Report
         uses: EnricoMi/publish-unit-test-result-action@v2.23.0
@@ -61,6 +56,51 @@ jobs:
           files: |
             app/build/test-results/**/TEST-*.xml
 
+      - name: Upload Reports
+        if: github.repository == 'jaredsburrows/android-gif-search' && github.ref == 'refs/heads/master'
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: com.burrowsapps.gif.search-reports-${{ github.workflow }}-${{ github.run_id }}
+          path: |
+            app/build/reports
+            app/build/test-results
+
+      - name: Upload Debug APK artifact
+        if: github.repository == 'jaredsburrows/android-gif-search' && github.ref == 'refs/heads/master'
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: com.burrowsapps.gif.search-debug-${{ github.workflow }}-${{ github.run_id }}.apk
+          path: app/build/outputs/apk/debug/app-debug.apk
+
+  instrumentation:
+    name: Instrumentation Tests
+    runs-on: ubuntu-latest
+
+    permissions:
+      checks: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout Project
+        uses: actions/checkout@v6.0.3
+
+      - name: Configure JDK ${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v5.2.0
+        with:
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
       - name: Cache AVD
         uses: actions/cache@v5.0.5
         id: avd-cache
@@ -68,13 +108,9 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-${{ env.ANDROID_API_LEVEL }}
-
-      - name: Enable KVM group perms
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
+          key: avd-${{ runner.os }}-api${{ env.ANDROID_API_LEVEL }}-v1
+          restore-keys: |
+            avd-${{ runner.os }}-api${{ env.ANDROID_API_LEVEL }}-
 
       - name: Create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
@@ -88,7 +124,7 @@ jobs:
           disable-animations: false
           script: echo "Generated AVD snapshot for caching."
 
-      - name: Run Debug Instrumentation Tests on Android API ${{ matrix.api-level }} (Ran up to 2 times)
+      - name: Run Debug Instrumentation Tests (Ran up to 2 times)
         uses: reactivecircus/android-emulator-runner@v2.37.0
         with:
           api-level: ${{ env.ANDROID_API_LEVEL }}
@@ -109,28 +145,35 @@ jobs:
           files: |
             app/build/outputs/androidTest-results/**/TEST-*.xml
 
-      - name: Build Debug APK artifact for upload
-        run: ./gradlew assembleDebug -s
-
-      - name: Build Release APK artifact for upload
-        run: ./gradlew assembleRelease -s
-
-      - name: Upload Reports
+      - name: Upload Integration Reports
         if: github.repository == 'jaredsburrows/android-gif-search' && github.ref == 'refs/heads/master'
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: com.burrowsapps.gif.search-reports-${{ github.workflow }}-${{ github.run_id }}
+          name: com.burrowsapps.gif.search-androidTest-reports-${{ github.workflow }}-${{ github.run_id }}
           path: |
-            app/build/reports
-            app/build/test-results
             app/build/outputs/androidTest-results
 
-      - name: Upload Debug APK artifact
-        if: github.repository == 'jaredsburrows/android-gif-search' && github.ref == 'refs/heads/master'
-        uses: actions/upload-artifact@v7.0.1
+  release:
+    name: Release Build (R8 smoke test)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Project
+        uses: actions/checkout@v6.0.3
+
+      - name: Configure JDK ${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v5.2.0
         with:
-          name: com.burrowsapps.gif.search-debug-${{ github.workflow }}-${{ github.run_id }}.apk
-          path: app/build/outputs/apk/debug/app-debug.apk
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+      - name: Build Release APK
+        run: ./gradlew assembleRelease -s
 
       - name: Upload Release APK artifact
         if: github.repository == 'jaredsburrows/android-gif-search' && github.ref == 'refs/heads/master'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,12 @@ on:
   pull_request:
     types: [ opened, labeled, unlabeled, synchronize ]
 
+# Cancel superseded runs for the same PR/branch (saves runner minutes on rapid pushes, e.g.
+# Renovate, and gives faster feedback on the latest commit); let master runs finish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 env:
   JAVA_VERSION: 25
   ANDROID_API_LEVEL: 36

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -98,7 +98,6 @@ android {
       isIncludeAndroidResources = true
     }
     animationsDisabled = true
-    execution = "ANDROIDX_TEST_ORCHESTRATOR"
   }
 
   dependenciesInfo {
@@ -217,7 +216,6 @@ dependencies {
   testImplementation(libs.robolectric)
 
   // Android Tests
-  androidTestUtil(libs.androidx.test.orchestrator)
   androidTestImplementation(projects.testResources)
   androidTestImplementation(libs.androidx.test.annotation)
   androidTestImplementation(libs.androidx.test.core)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,6 +29,7 @@ android {
     targetSdk {
       version = release(sdkVersion)
     }
+    manifestPlaceholders["applicationName"] = ".MainApplication"
 
     testApplicationId = "com.burrowsapps.gif.search.test"
     testInstrumentationRunner = "com.burrowsapps.gif.search.test.CustomTestRunner"
@@ -78,6 +79,7 @@ android {
     debug {
       applicationIdSuffix = ".debug"
       versionNameSuffix = "-dev"
+      manifestPlaceholders["applicationName"] = ".DebugApplication"
       signingConfig = signingConfigs.getByName("debug")
     }
 

--- a/app/src/androidTest/java/com/burrowsapps/gif/search/ui/giflist/GifScreenTest.kt
+++ b/app/src/androidTest/java/com/burrowsapps/gif/search/ui/giflist/GifScreenTest.kt
@@ -5,7 +5,7 @@ import android.content.Context
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.isDialog
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -75,7 +75,7 @@ class GifScreenTest {
     // Disable auto-advance so that Compose does not wait indefinitely for idle.
     // Landscapist 2.9.x introduces produceState coroutines (rememberImageSourceFile) and
     // explicit Loading state emissions that, combined with animated GIF drawables, prevent
-    // Compose from ever reaching a fully idle state within the test timeout.
+    // Jetpack Compose of ever reaching a fully idle state within the test timeout.
     composeTestRule.mainClock.autoAdvance = false
     composeTestRule.mainClock.advanceTimeByFrame()
     composeTestRule.waitForIdle()
@@ -133,7 +133,7 @@ class GifScreenTest {
 
   @Test
   fun testTrendingThenClickOpenDialog() {
-    // Wait until the gifs are showing
+    // Wait until the GIFs are showing
     composeTestRule.waitUntil(
       condition = {
         composeTestRule.mainClock.advanceTimeByFrame()
@@ -166,7 +166,7 @@ class GifScreenTest {
 
   @Test
   fun testTrendingThenClickOpenDialogAndCopyLink() {
-    // Wait until the gifs are showing
+    // Wait until the GIFs are showing
     composeTestRule.waitUntil(
       condition = {
         composeTestRule.mainClock.advanceTimeByFrame()

--- a/app/src/androidTest/java/com/burrowsapps/gif/search/ui/license/LicenseScreenTest.kt
+++ b/app/src/androidTest/java/com/burrowsapps/gif/search/ui/license/LicenseScreenTest.kt
@@ -2,7 +2,7 @@ package com.burrowsapps.gif.search.ui.license
 
 import android.content.Context
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -69,7 +69,7 @@ class LicenseScreenTest {
     // Disable auto-advance so that Compose does not wait indefinitely for idle.
     // Landscapist 2.9.x introduces produceState coroutines (rememberImageSourceFile) and
     // explicit Loading state emissions that, combined with animated GIF drawables, prevent
-    // Compose from ever reaching a fully idle state within the test timeout.
+    // Jetpack Compose of ever reaching a fully idle state within the test timeout.
     composeTestRule.mainClock.autoAdvance = false
     composeTestRule.mainClock.advanceTimeByFrame()
     composeTestRule.waitForIdle()

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:tools="http://schemas.android.com/tools">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
@@ -8,9 +7,7 @@
   <!-- Keep usesCleartextTraffic for androidTests -->
   <!-- Allow network inspection for debug builds defined in debug_network_security_config-->
   <application
-    android:name=".DebugApplication"
     android:icon="@mipmap/ic_launcher"
     android:networkSecurityConfig="@xml/debug_network_security_config"
-    android:usesCleartextTraffic="true"
-    tools:replace="android:name" />
+    android:usesCleartextTraffic="true" />
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
   <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
   <application
-    android:name=".MainApplication"
+    android:name="${applicationName}"
     android:allowBackup="true"
     android:dataExtractionRules="@xml/data_extraction_rules"
     android:enableOnBackInvokedCallback="true"

--- a/app/src/test/java/com/burrowsapps/gif/search/data/api/GifServiceTest.kt
+++ b/app/src/test/java/com/burrowsapps/gif/search/data/api/GifServiceTest.kt
@@ -11,8 +11,8 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.HiltTestApplication
 import dagger.hilt.android.testing.UninstallModules
 import kotlinx.coroutines.Dispatchers.IO
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
 import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -76,7 +76,7 @@ class GifServiceTest {
   @Test
   fun testTrendingResultsURLShouldParseCorrectly() =
     runTest {
-      val response = runBlocking(IO) { sut.fetchTrendingResults(null) }
+      val response = withContext(IO) { sut.fetchTrendingResults(null) }
       val body = response.body()!!
 
       assertThat(
@@ -91,7 +91,7 @@ class GifServiceTest {
   @Test
   fun testTrendingResultsURLPreviewShouldParseCorrectly() =
     runTest {
-      val response = runBlocking(IO) { sut.fetchTrendingResults(null) }
+      val response = withContext(IO) { sut.fetchTrendingResults(null) }
       val body = response.body()!!
 
       assertThat(
@@ -106,7 +106,7 @@ class GifServiceTest {
   @Test
   fun testSearchResultsURLShouldParseCorrectly() =
     runTest {
-      val response = runBlocking(IO) { sut.fetchSearchResults("hello", null) }
+      val response = withContext(IO) { sut.fetchSearchResults("hello", null) }
       val body = response.body()!!
 
       assertThat(
@@ -121,7 +121,7 @@ class GifServiceTest {
   @Test
   fun testSearchResultsURLPreviewShouldParseCorrectly() =
     runTest {
-      val response = runBlocking(IO) { sut.fetchSearchResults("hello", null) }
+      val response = withContext(IO) { sut.fetchSearchResults("hello", null) }
       val body = response.body()!!
 
       assertThat(

--- a/app/src/test/java/com/burrowsapps/gif/search/data/api/model/GifDtoTest.kt
+++ b/app/src/test/java/com/burrowsapps/gif/search/data/api/model/GifDtoTest.kt
@@ -1,43 +1,25 @@
 package com.burrowsapps.gif.search.data.api.model
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.burrowsapps.gif.search.di.ApiConfigModule
+import com.burrowsapps.gif.search.di.NetworkModule
 import com.google.common.truth.Truth.assertThat
 import com.squareup.moshi.JsonDataException
 import com.squareup.moshi.Moshi
-import dagger.hilt.android.testing.HiltAndroidRule
-import dagger.hilt.android.testing.HiltAndroidTest
-import dagger.hilt.android.testing.HiltTestApplication
-import dagger.hilt.android.testing.UninstallModules
-import jakarta.inject.Inject
 import org.junit.Assert.assertThrows
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.annotation.Config
 
-@HiltAndroidTest
-@UninstallModules(ApiConfigModule::class)
-@Config(application = HiltTestApplication::class)
-@RunWith(AndroidJUnit4::class)
 class GifDtoTest {
   private val gifUrl = "https://media.tenor.com/images/ed8cf447392c5e7e0cc16cbad2a0edce/tenor.gif"
   private val previewUrl = "https://media.tenor.com/images/b1060f2602934944c0e3502a1d7d20d8/raw"
   private var defaultSut = GifDto()
   private lateinit var sut: GifDto
 
-  @get:Rule(order = 0)
-  internal val hiltRule = HiltAndroidRule(this)
-
-  @Inject
   internal lateinit var moshi: Moshi
 
   @Before
   fun setUp() {
-    hiltRule.inject()
-
     sut = GifDto(gifUrl, previewUrl)
+    moshi = NetworkModule().provideMoshi()
   }
 
   @Test

--- a/app/src/test/java/com/burrowsapps/gif/search/data/api/model/GifResponseDtoTest.kt
+++ b/app/src/test/java/com/burrowsapps/gif/search/data/api/model/GifResponseDtoTest.kt
@@ -1,26 +1,13 @@
 package com.burrowsapps.gif.search.data.api.model
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.burrowsapps.gif.search.di.ApiConfigModule
+import com.burrowsapps.gif.search.di.NetworkModule
 import com.google.common.truth.Truth.assertThat
 import com.squareup.moshi.JsonDataException
 import com.squareup.moshi.Moshi
-import dagger.hilt.android.testing.HiltAndroidRule
-import dagger.hilt.android.testing.HiltAndroidTest
-import dagger.hilt.android.testing.HiltTestApplication
-import dagger.hilt.android.testing.UninstallModules
-import jakarta.inject.Inject
 import org.junit.Assert.assertThrows
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.annotation.Config
 
-@HiltAndroidTest
-@UninstallModules(ApiConfigModule::class)
-@Config(application = HiltTestApplication::class)
-@RunWith(AndroidJUnit4::class)
 class GifResponseDtoTest {
   private val gifDto = GifDto()
   private val mediaDto = MediaDto(tinyGif = gifDto, gif = gifDto)
@@ -30,16 +17,12 @@ class GifResponseDtoTest {
   private var sutDefault = GifResponseDto()
   private lateinit var sut: GifResponseDto
 
-  @get:Rule(order = 0)
-  internal val hiltRule = HiltAndroidRule(this)
-
-  @Inject
   internal lateinit var moshi: Moshi
 
   @Before
   fun setUp() {
-    hiltRule.inject()
     sut = GifResponseDto(results = results, next = nextResponse)
+    moshi = NetworkModule().provideMoshi()
   }
 
   @Test

--- a/app/src/test/java/com/burrowsapps/gif/search/data/api/model/MediaDtoTest.kt
+++ b/app/src/test/java/com/burrowsapps/gif/search/data/api/model/MediaDtoTest.kt
@@ -1,41 +1,24 @@
 package com.burrowsapps.gif.search.data.api.model
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.burrowsapps.gif.search.di.ApiConfigModule
+import com.burrowsapps.gif.search.di.NetworkModule
 import com.google.common.truth.Truth.assertThat
 import com.squareup.moshi.JsonDataException
 import com.squareup.moshi.Moshi
-import dagger.hilt.android.testing.HiltAndroidRule
-import dagger.hilt.android.testing.HiltAndroidTest
-import dagger.hilt.android.testing.HiltTestApplication
-import dagger.hilt.android.testing.UninstallModules
-import jakarta.inject.Inject
 import org.junit.Assert.assertThrows
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.annotation.Config
 
-@HiltAndroidTest
-@UninstallModules(ApiConfigModule::class)
-@Config(application = HiltTestApplication::class)
-@RunWith(AndroidJUnit4::class)
 class MediaDtoTest {
   private val gifDto = GifDto()
   private var defaultSut = MediaDto()
   private lateinit var sut: MediaDto
 
-  @get:Rule(order = 0)
-  internal val hiltRule = HiltAndroidRule(this)
-
-  @Inject
   internal lateinit var moshi: Moshi
 
   @Before
   fun setUp() {
-    hiltRule.inject()
     sut = MediaDto(tinyGif = gifDto, gif = gifDto)
+    moshi = NetworkModule().provideMoshi()
   }
 
   @Test

--- a/app/src/test/java/com/burrowsapps/gif/search/data/api/model/NetworkResultTest.kt
+++ b/app/src/test/java/com/burrowsapps/gif/search/data/api/model/NetworkResultTest.kt
@@ -1,27 +1,24 @@
 package com.burrowsapps.gif.search.data.api.model
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.burrowsapps.gif.search.data.api.model.NetworkResult.Companion.safeApiCall
 import com.burrowsapps.gif.search.data.api.model.NetworkResult.Empty
 import com.burrowsapps.gif.search.data.api.model.NetworkResult.Error
 import com.burrowsapps.gif.search.data.api.model.NetworkResult.Success
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.Dispatchers.IO
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Test
-import org.junit.runner.RunWith
 import retrofit2.Response
 import java.net.HttpURLConnection.HTTP_INTERNAL_ERROR
 
-@RunWith(AndroidJUnit4::class)
 class NetworkResultTest {
   @Test
   fun testSafeApiCallReturnsSuccessWhenResponseIsSuccessfulAndHasBody() =
     runTest {
       val result =
-        runBlocking(IO) {
+        withContext(IO) {
           safeApiCall {
             Response.success("body")
           }
@@ -35,7 +32,7 @@ class NetworkResultTest {
   fun testSafeApiCallReturnsEmptyWhenResponseIsSuccessfulAndHasNoBody() =
     runTest {
       val result =
-        runBlocking(IO) {
+        withContext(IO) {
           safeApiCall {
             Response.success(null)
           }
@@ -49,7 +46,7 @@ class NetworkResultTest {
   fun testSafeApiCallReturnsErrorWhenResponseIsNotSuccessful() =
     runTest {
       val result =
-        runBlocking(IO) {
+        withContext(IO) {
           safeApiCall {
             Response.error<String>(HTTP_INTERNAL_ERROR, "error".toResponseBody())
           }
@@ -63,7 +60,7 @@ class NetworkResultTest {
   fun testSafeApiCallReturnsErrorWhenAPICallThrowsException() =
     runTest {
       val result =
-        runBlocking(IO) {
+        withContext(IO) {
           safeApiCall<String> {
             throw RuntimeException("API call failed")
           }

--- a/app/src/test/java/com/burrowsapps/gif/search/data/api/model/ResultDtoTest.kt
+++ b/app/src/test/java/com/burrowsapps/gif/search/data/api/model/ResultDtoTest.kt
@@ -1,26 +1,13 @@
 package com.burrowsapps.gif.search.data.api.model
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.burrowsapps.gif.search.di.ApiConfigModule
+import com.burrowsapps.gif.search.di.NetworkModule
 import com.google.common.truth.Truth.assertThat
 import com.squareup.moshi.JsonDataException
 import com.squareup.moshi.Moshi
-import dagger.hilt.android.testing.HiltAndroidRule
-import dagger.hilt.android.testing.HiltAndroidTest
-import dagger.hilt.android.testing.HiltTestApplication
-import dagger.hilt.android.testing.UninstallModules
-import jakarta.inject.Inject
 import org.junit.Assert.assertThrows
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.annotation.Config
 
-@HiltAndroidTest
-@UninstallModules(ApiConfigModule::class)
-@Config(application = HiltTestApplication::class)
-@RunWith(AndroidJUnit4::class)
 class ResultDtoTest {
   private val gifDto = GifDto()
   private val mediaDto = MediaDto(tinyGif = gifDto, gif = gifDto)
@@ -28,16 +15,12 @@ class ResultDtoTest {
   private var sutDefault = ResultDto()
   private lateinit var sut: ResultDto
 
-  @get:Rule(order = 0)
-  internal val hiltRule = HiltAndroidRule(this)
-
-  @Inject
   internal lateinit var moshi: Moshi
 
   @Before
   fun setUp() {
-    hiltRule.inject()
     sut = ResultDto(media = mediaList)
+    moshi = NetworkModule().provideMoshi()
   }
 
   @Test

--- a/app/src/test/java/com/burrowsapps/gif/search/data/db/entity/GifEntityTest.kt
+++ b/app/src/test/java/com/burrowsapps/gif/search/data/db/entity/GifEntityTest.kt
@@ -9,14 +9,14 @@ class GifEntityTest {
     val entity =
       GifEntity(
         tinyGifUrl = "tiny",
-        tinyGifPreviewUrl = "tinyp",
+        tinyGifPreviewUrl = "tiny-preview",
         gifUrl = "gif",
-        gifPreviewUrl = "gifp",
+        gifPreviewUrl = "gif-preview",
       )
 
     assertThat(entity.tinyGifUrl).isEqualTo("tiny")
-    assertThat(entity.tinyGifPreviewUrl).isEqualTo("tinyp")
+    assertThat(entity.tinyGifPreviewUrl).isEqualTo("tiny-preview")
     assertThat(entity.gifUrl).isEqualTo("gif")
-    assertThat(entity.gifPreviewUrl).isEqualTo("gifp")
+    assertThat(entity.gifPreviewUrl).isEqualTo("gif-preview")
   }
 }

--- a/app/src/test/java/com/burrowsapps/gif/search/data/db/entity/GifEntityTest.kt
+++ b/app/src/test/java/com/burrowsapps/gif/search/data/db/entity/GifEntityTest.kt
@@ -1,11 +1,8 @@
 package com.burrowsapps.gif.search.data.db.entity
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
-import org.junit.runner.RunWith
 
-@RunWith(AndroidJUnit4::class)
 class GifEntityTest {
   @Test
   fun fields_areAssigned() {

--- a/app/src/test/java/com/burrowsapps/gif/search/data/db/entity/QueryResultEntityTest.kt
+++ b/app/src/test/java/com/burrowsapps/gif/search/data/db/entity/QueryResultEntityTest.kt
@@ -1,11 +1,8 @@
 package com.burrowsapps.gif.search.data.db.entity
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
-import org.junit.runner.RunWith
 
-@RunWith(AndroidJUnit4::class)
 class QueryResultEntityTest {
   @Test
   fun fields_areAssigned() {

--- a/app/src/test/java/com/burrowsapps/gif/search/data/db/entity/RemoteKeysEntityTest.kt
+++ b/app/src/test/java/com/burrowsapps/gif/search/data/db/entity/RemoteKeysEntityTest.kt
@@ -1,11 +1,8 @@
 package com.burrowsapps.gif.search.data.db.entity
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
-import org.junit.runner.RunWith
 
-@RunWith(AndroidJUnit4::class)
 class RemoteKeysEntityTest {
   @Test
   fun fields_areAssigned() {

--- a/app/src/test/java/com/burrowsapps/gif/search/data/repository/GifRemoteMediatorTest.kt
+++ b/app/src/test/java/com/burrowsapps/gif/search/data/repository/GifRemoteMediatorTest.kt
@@ -215,7 +215,7 @@ class GifRemoteMediatorTest {
   fun error_returnsError() =
     runTest(dispatcher) {
       whenever(repository.getTrendingResults(anyOrNull())).thenReturn(
-        NetworkResult.Error<GifResponseDto>(
+        NetworkResult.Error(
           message = "boom",
         ),
       )
@@ -353,7 +353,7 @@ class GifRemoteMediatorTest {
       assertThat(allGifsAfterCats).hasSize(2)
       assertThat(allGifsAfterCats.all { it.tinyGifUrl.contains("cat") }).isTrue()
 
-      // Now REFRESH the same "cats" query multiple times to trigger cleanup
+      // Now REFRESH the same "cats" query multiple times to trigger clean up
       // Cleanup runs every 5th refresh due to throttling
       whenever(repository.getSearchResults("cats", null))
         .thenReturn(NetworkResult.Success(response(2, "dog", next = "5.0")))

--- a/app/src/test/java/com/burrowsapps/gif/search/data/repository/GifRepositoryTest.kt
+++ b/app/src/test/java/com/burrowsapps/gif/search/data/repository/GifRepositoryTest.kt
@@ -1,6 +1,5 @@
 package com.burrowsapps.gif.search.data.repository
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.burrowsapps.gif.search.data.api.GifService
 import com.burrowsapps.gif.search.data.api.model.GifResponseDto
 import com.burrowsapps.gif.search.test.TestFileUtils.MOCK_SERVER_URL
@@ -11,7 +10,6 @@ import okhttp3.Protocol.HTTP_1_1
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -20,7 +18,6 @@ import org.mockito.kotlin.whenever
 import retrofit2.Response
 import java.net.HttpURLConnection.HTTP_INTERNAL_ERROR
 
-@RunWith(AndroidJUnit4::class)
 class GifRepositoryTest {
   private val service = mock<GifService>()
   private val next = "0.0"

--- a/app/src/test/java/com/burrowsapps/gif/search/di/NetworkModuleTest.kt
+++ b/app/src/test/java/com/burrowsapps/gif/search/di/NetworkModuleTest.kt
@@ -9,7 +9,6 @@ import com.google.common.truth.Truth.assertThat
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapters.Rfc3339DateJsonAdapter
 import kotlinx.coroutines.Dispatchers.IO
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
@@ -58,7 +57,8 @@ class NetworkModuleTest {
     val converterFactory = MoshiConverterFactory.create(moshi)
     val client = OkHttpClient.Builder().build()
     val lazyClient = dagger.Lazy { client }
-    val retrofit = networkModule.provideRetrofit(converterFactory, lazyClient, "https://example.com")
+    val retrofit =
+      networkModule.provideRetrofit(converterFactory, lazyClient, "https://example.com")
 
     assertThat(retrofit.baseUrl().toString()).isEqualTo("https://example.com/")
   }
@@ -82,22 +82,20 @@ class NetworkModuleTest {
   @Test
   fun provideOkHttpClientReturnsOkHttpClient() =
     runTest {
-      runBlocking {
-        withContext(IO) {
-          val loggingInterceptor = networkModule.provideHttpLoggingInterceptor(TESTING)
-          val eventListener = networkModule.provideEventListener()
-          val cache = networkModule.provideCache(context)
+      withContext(IO) {
+        val loggingInterceptor = networkModule.provideHttpLoggingInterceptor(TESTING)
+        val eventListener = networkModule.provideEventListener()
+        val cache = networkModule.provideCache(context)
 
-          val client = networkModule.provideOkHttpClient(loggingInterceptor, eventListener, cache)
+        val client = networkModule.provideOkHttpClient(loggingInterceptor, eventListener, cache)
 
-          assertThat(client.cache).isEqualTo(cache)
-          assertThat(client.interceptors).contains(loggingInterceptor)
-          // Verify the configured event listener is used by the client
-          val request = Request.Builder().url("https://example.com").build()
-          val call = client.newCall(request)
-          val created = client.eventListenerFactory.create(call)
-          assertThat(created::class.java.name).isEqualTo(eventListener::class.java.name)
-        }
+        assertThat(client.cache).isEqualTo(cache)
+        assertThat(client.interceptors).contains(loggingInterceptor)
+        // Verify the configured event listener is used by the client
+        val request = Request.Builder().url("https://example.com").build()
+        val call = client.newCall(request)
+        val created = client.eventListenerFactory.create(call)
+        assertThat(created::class.java.name).isEqualTo(eventListener::class.java.name)
       }
     }
 
@@ -119,13 +117,11 @@ class NetworkModuleTest {
   @Test
   fun provideCacheReturnsCache() =
     runTest {
-      runBlocking {
-        withContext(IO) {
-          val cache = networkModule.provideCache(context)
+      withContext(IO) {
+        val cache = networkModule.provideCache(context)
 
-          assertThat(cache.directory).isEqualTo(context.cacheDir)
-          assertThat(cache.maxSize()).isEqualTo(50 * 1024 * 1024L)
-        }
+        assertThat(cache.directory).isEqualTo(context.cacheDir)
+        assertThat(cache.maxSize()).isEqualTo(50 * 1024 * 1024L)
       }
     }
 }

--- a/app/src/test/java/com/burrowsapps/gif/search/ui/giflist/GifImageInfoTest.kt
+++ b/app/src/test/java/com/burrowsapps/gif/search/ui/giflist/GifImageInfoTest.kt
@@ -1,12 +1,9 @@
 package com.burrowsapps.gif.search.ui.giflist
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
 
-@RunWith(AndroidJUnit4::class)
 class GifImageInfoTest {
   private val gifUrl = "https://media.tenor.com/images/ed8cf447392c5e7e0cc16cbad2a0edce/tenor.gif"
   private val previewUrl = "https://media.tenor.com/images/b1060f2602934944c0e3502a1d7d20d8/raw"

--- a/app/src/test/java/com/burrowsapps/gif/search/ui/giflist/GifScreenTest.kt
+++ b/app/src/test/java/com/burrowsapps/gif/search/ui/giflist/GifScreenTest.kt
@@ -3,7 +3,7 @@ package com.burrowsapps.gif.search.ui.giflist
 import android.content.Context
 import androidx.compose.material3.SearchBarDefaults
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/app/src/test/java/com/burrowsapps/gif/search/ui/license/LicenseScreenTest.kt
+++ b/app/src/test/java/com/burrowsapps/gif/search/ui/license/LicenseScreenTest.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.navigation.compose.NavHost

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -140,8 +140,10 @@ subprojects {
             "-Xlint:all",
             // Ignore "warning: No processor claimed any of these annotations"
             "-Xlint:-processing",
-            "-Xmaxerrs", "10000",
-            "-Xmaxwarns", "10000",
+            "-Xmaxerrs",
+            "10000",
+            "-Xmaxwarns",
+            "10000",
           ),
         )
         encoding = "utf-8"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ idea {
 }
 
 tasks.withType<Wrapper>().configureEach {
-  distributionType = Wrapper.DistributionType.ALL
+  distributionType = Wrapper.DistributionType.BIN
 }
 
 allprojects {
@@ -91,7 +91,6 @@ allprojects {
         )
       compilerArgs.addAll(listOf("-Xmaxerrs", "10000", "-Xmaxwarns", "10000"))
       encoding = "utf-8"
-      isFork = true
     }
   }
 
@@ -107,8 +106,9 @@ allprojects {
     // For mockito to work with JDK 21
     jvmArgs("-Dnet.bytebuddy.experimental=true")
 
-    val maxWorkerCount = gradle.startParameter.maxWorkerCount
-    maxParallelForks = if (maxWorkerCount < 2) 1 else maxWorkerCount / 2
+    // Derived from the machine (not gradle.startParameter) so the value is stable across
+    // configuration-cache reuse. Half the cores matches the previous behaviour.
+    maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(1)
   }
 
   tasks.configureEach {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -173,18 +173,6 @@ subprojects {
         },
       )
     }
-
-    tasks.configureEach {
-      when (this) {
-        is JavaForkOptions -> {
-          // should improve memory on a 64bit JVM
-          jvmArgs("-XX:+UseCompressedOops")
-          // should avoid GradleWorkerMain to steal focus
-          jvmArgs("-Djava.awt.headless=true")
-          jvmArgs("-Dapple.awt.UIElement=true")
-        }
-      }
-    }
   }
 
   // Compose/Paging opt-in markers only exist in :app; opting in here (com.android.application,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,27 +32,82 @@ tasks.withType<Wrapper>().configureEach {
   distributionType = Wrapper.DistributionType.BIN
 }
 
-allprojects {
-  apply(plugin = "org.jlleitschuh.gradle.ktlint")
+tasks.withType<DependencyUpdatesTask>().configureEach {
+  fun isNonStable(version: String): Boolean {
+    val stableKeyword =
+      listOf("RELEASE", "FINAL", "GA")
+        .any { version.uppercase(Locale.getDefault()).contains(it) }
+    val regex = "^[0-9,.v-]+(-r)?$".toRegex()
+    val isStable = stableKeyword || regex.matches(version)
+    return !isStable
+  }
 
-  tasks.withType<DependencyUpdatesTask>().configureEach {
-    fun isNonStable(version: String): Boolean {
-      val stableKeyword =
-        listOf("RELEASE", "FINAL", "GA")
-          .any { version.uppercase(Locale.getDefault()).contains(it) }
-      val regex = "^[0-9,.v-]+(-r)?$".toRegex()
-      val isStable = stableKeyword || regex.matches(version)
-      return !isStable
+  rejectVersionIf {
+    val allowNonStableForGroup =
+      candidate.group in setOf("com.android.application", "org.jetbrains.kotlin")
+    if (allowNonStableForGroup) {
+      false
+    } else {
+      isNonStable(candidate.version) && !isNonStable(currentVersion)
     }
+  }
+}
 
-    rejectVersionIf {
-      val allowNonStableForGroup =
-        candidate.group in setOf("com.android.application", "org.jetbrains.kotlin")
-      if (allowNonStableForGroup) {
-        false
-      } else {
-        isNonStable(candidate.version) && !isNonStable(currentVersion)
+subprojects {
+  plugins.withId("org.jlleitschuh.gradle.ktlint") {
+    configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {
+      reporters {
+        reporter(HTML)
       }
+    }
+  }
+
+  plugins.withId("com.android.base") {
+    val sdkVersion =
+      libs.versions.sdk
+        .get()
+        .toInt()
+
+    extensions.configure<CommonExtension> {
+      compileSdk {
+        version =
+          release(sdkVersion) {
+            minorApiLevel = 1
+          }
+      }
+
+      defaultConfig.apply {
+        minSdk {
+          version = release(sdkVersion)
+        }
+      }
+
+      compileOptions.apply {
+        sourceCompatibility = VERSION_21
+        targetCompatibility = VERSION_21
+      }
+
+      lint.apply {
+        abortOnError = true
+        checkAllWarnings = true
+        warningsAsErrors = true
+        checkTestSources = true
+        checkDependencies = true
+        checkReleaseBuilds = false
+        lintConfig = rootDir.resolve("config/lint/lint.xml")
+        textReport = true
+        sarifReport = true
+      }
+
+      packaging.resources.excludes +=
+        listOf(
+          "**/*.kotlin_module",
+          "**/*.version",
+          "**/kotlin/**",
+          "**/*.txt",
+          "**/*.xml",
+          "**/*.properties",
+        )
     }
   }
 
@@ -106,8 +161,6 @@ allprojects {
     // For mockito to work with JDK 21
     jvmArgs("-Dnet.bytebuddy.experimental=true")
 
-    // Derived from the machine (not gradle.startParameter) so the value is stable across
-    // configuration-cache reuse. Half the cores matches the previous behaviour.
     maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(1)
   }
 
@@ -120,63 +173,6 @@ allprojects {
         jvmArgs("-Djava.awt.headless=true")
         jvmArgs("-Dapple.awt.UIElement=true")
       }
-    }
-  }
-}
-
-subprojects {
-  ktlint {
-    reporters {
-      reporter(HTML)
-    }
-  }
-
-  plugins.withId("com.android.base") {
-    val sdkVersion =
-      libs.versions.sdk
-        .get()
-        .toInt()
-
-    extensions.configure<CommonExtension> {
-      compileSdk {
-        version =
-          release(sdkVersion) {
-            minorApiLevel = 1
-          }
-      }
-
-      defaultConfig.apply {
-        minSdk {
-          version = release(sdkVersion)
-        }
-      }
-
-      compileOptions.apply {
-        sourceCompatibility = VERSION_21
-        targetCompatibility = VERSION_21
-      }
-
-      lint.apply {
-        abortOnError = true
-        checkAllWarnings = true
-        warningsAsErrors = true
-        checkTestSources = true
-        checkDependencies = true
-        checkReleaseBuilds = false
-        lintConfig = rootDir.resolve("config/lint/lint.xml")
-        textReport = true
-        sarifReport = true
-      }
-
-      packaging.resources.excludes +=
-        listOf(
-          "**/*.kotlin_module",
-          "**/*.version",
-          "**/kotlin/**",
-          "**/*.txt",
-          "**/*.xml",
-          "**/*.properties",
-        )
     }
   }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -110,12 +110,60 @@ subprojects {
         )
     }
 
+    tasks.withType<KotlinJvmCompile>().configureEach {
+      compilerOptions {
+        jvmTarget.set(JVM_21)
+        freeCompilerArgs.addAll(
+          // https://kotlinlang.org/docs/compiler-reference.html#progressive
+          "-progressive",
+          "-Xjsr305=strict",
+          "-Xemit-jvm-type-annotations",
+          // https://publicobject.com/2019/11/18/kotlins-assert-is-not-like-javas-assert/
+          "-Xassertions=jvm",
+          // Generate JVM default methods for Kotlin interfaces
+          "-jvm-default=enable",
+          "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
+          "-opt-in=kotlinx.coroutines.FlowPreview",
+        )
+      }
+    }
+
+    tasks.withType<JavaCompile>().configureEach {
+      sourceCompatibility = VERSION_21.toString()
+      targetCompatibility = VERSION_21.toString()
+
+      // Show all warnings except boot classpath
+      options.apply {
+        compilerArgs.addAll(
+          listOf(
+            // Turn on all warnings
+            "-Xlint:all",
+            // Ignore "warning: No processor claimed any of these annotations"
+            "-Xlint:-processing",
+            "-Xmaxerrs", "10000",
+            "-Xmaxwarns", "10000",
+          ),
+        )
+        encoding = "utf-8"
+      }
+    }
+
     // Attach mockito agent for tests to work with JDK 21+
     val mockitoAgent = configurations.create("mockitoAgent")
     dependencies {
       add("mockitoAgent", libs.mockito)
     }
     tasks.withType<Test>().configureEach {
+      testLogging {
+        exceptionFormat = FULL
+        showCauses = true
+        showExceptions = true
+        showStackTraces = true
+        events = setOf(FAILED, SKIPPED)
+      }
+
+      maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(1)
+
       val agentFiles = mockitoAgent.incoming.files
       jvmArgumentProviders.add(
         CommandLineArgumentProvider {
@@ -123,66 +171,29 @@ subprojects {
         },
       )
     }
-  }
 
-  tasks.withType<KotlinJvmCompile>().configureEach {
-    compilerOptions {
-      jvmTarget.set(JVM_21)
-      freeCompilerArgs.addAll(
-        // https://kotlinlang.org/docs/compiler-reference.html#progressive
-        "-progressive",
-        "-Xjsr305=strict",
-        "-Xemit-jvm-type-annotations",
-        // https://publicobject.com/2019/11/18/kotlins-assert-is-not-like-javas-assert/
-        "-Xassertions=jvm",
-        // Generate JVM default methods for Kotlin interfaces
-        "-jvm-default=enable",
-        "-opt-in=androidx.compose.material3.ExperimentalMaterial3Api",
-        "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
-        "-opt-in=androidx.paging.ExperimentalPagingApi",
-        "-opt-in=kotlinx.coroutines.FlowPreview",
-      )
+    tasks.configureEach {
+      when (this) {
+        is JavaForkOptions -> {
+          // should improve memory on a 64bit JVM
+          jvmArgs("-XX:+UseCompressedOops")
+          // should avoid GradleWorkerMain to steal focus
+          jvmArgs("-Djava.awt.headless=true")
+          jvmArgs("-Dapple.awt.UIElement=true")
+        }
+      }
     }
   }
 
-  tasks.withType<JavaCompile>().configureEach {
-    sourceCompatibility = VERSION_21.toString()
-    targetCompatibility = VERSION_21.toString()
-
-    // Show all warnings except boot classpath
-    options.apply {
-      compilerArgs = compilerArgs +
-        listOf(
-          // Turn on all warnings
-          "-Xlint:all",
-          // Ignore "warning: No processor claimed any of these annotations"
-          "-Xlint:-processing",
+  // Compose/Paging opt-in markers only exist in :app; opting in here (com.android.application,
+  // not com.android.base) avoids unresolved-marker warnings in the :test-resources library.
+  plugins.withId("com.android.application") {
+    tasks.withType<KotlinJvmCompile>().configureEach {
+      compilerOptions {
+        freeCompilerArgs.addAll(
+          "-opt-in=androidx.compose.material3.ExperimentalMaterial3Api",
+          "-opt-in=androidx.paging.ExperimentalPagingApi",
         )
-      compilerArgs.addAll(listOf("-Xmaxerrs", "10000", "-Xmaxwarns", "10000"))
-      encoding = "utf-8"
-    }
-  }
-
-  tasks.withType<Test>().configureEach {
-    testLogging {
-      exceptionFormat = FULL
-      showCauses = true
-      showExceptions = true
-      showStackTraces = true
-      events = setOf(FAILED, SKIPPED)
-    }
-
-    maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(1)
-  }
-
-  tasks.configureEach {
-    when (this) {
-      is JavaForkOptions -> {
-        // should improve memory on a 64bit JVM
-        jvmArgs("-XX:+UseCompressedOops")
-        // should avoid GradleWorkerMain to steal focus
-        jvmArgs("-Djava.awt.headless=true")
-        jvmArgs("-Dapple.awt.UIElement=true")
       }
     }
   }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -109,6 +109,20 @@ subprojects {
           "**/*.properties",
         )
     }
+
+    // Attach mockito agent for tests to work with JDK 21+
+    val mockitoAgent = configurations.create("mockitoAgent")
+    dependencies {
+      add("mockitoAgent", libs.mockito)
+    }
+    tasks.withType<Test>().configureEach {
+      val agentFiles = mockitoAgent.incoming.files
+      jvmArgumentProviders.add(
+        CommandLineArgumentProvider {
+          listOf("-javaagent:${agentFiles.single { it.name.startsWith("mockito-core") }}")
+        },
+      )
+    }
   }
 
   tasks.withType<KotlinJvmCompile>().configureEach {
@@ -157,9 +171,6 @@ subprojects {
       showStackTraces = true
       events = setOf(FAILED, SKIPPED)
     }
-
-    // For mockito to work with JDK 21
-    jvmArgs("-Dnet.bytebuddy.experimental=true")
 
     maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(1)
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,12 @@
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 
+# Build performance: cache task outputs, reuse the configuration phase, build modules
+# in parallel, and watch the filesystem for faster incremental builds.
+org.gradle.caching=true
+org.gradle.configuration-cache=true
+org.gradle.parallel=true
+org.gradle.vfs.watch=true
+
 android.enableR8.fullMode=true
 android.enableResourceOptimizations=true
 android.injected.studio.version.check=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,13 +2,6 @@ org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 org.gradle.caching=true
 org.gradle.configuration-cache=true
 org.gradle.parallel=true
-org.gradle.vfs.watch=true
-
-android.enableR8.fullMode=true
-android.enableResourceOptimizations=true
-android.injected.studio.version.check=false
-android.nonTransitiveRClass=true
-android.useAndroidX=true
 
 android.defaults.buildfeatures.databinding=false
 android.defaults.buildfeatures.prefab=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,14 +1,6 @@
-org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC
 org.gradle.caching=true
 org.gradle.configuration-cache=true
 org.gradle.parallel=true
 
-android.defaults.buildfeatures.databinding=false
-android.defaults.buildfeatures.prefab=false
-android.defaults.buildfeatures.resvalues=false
-android.defaults.buildfeatures.shaders=false
-android.defaults.buildfeatures.viewbinding=false
-
 android.newDsl=false
-
-kotlin.code.style=official

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,4 @@
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
-
-# Build performance: cache task outputs, reuse the configuration phase, build modules
-# in parallel, and watch the filesystem for faster incremental builds.
 org.gradle.caching=true
 org.gradle.configuration-cache=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,6 @@ org.gradle.caching=true
 org.gradle.configuration-cache=true
 org.gradle.parallel=true
 
+# Required by legacy plugins (dexcount/license) that still use AGP's old AppExtension DSL.
+# AGP 9 deprecates this flag; keep it until those plugins migrate to the new DSL.
 android.newDsl=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,7 +45,6 @@ androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "
 androidx-test-annotation = { module = "androidx.test:annotation", version = "1.0.1" }
 androidx-test-core = { module = "androidx.test:core-ktx", version = "1.7.0" }
 androidx-test-junit = { module = "androidx.test.ext:junit-ktx", version = "1.3.0" }
-androidx-test-orchestrator = { module = "androidx.test:orchestrator", version = "1.6.1" }
 androidx-test-rules = { module = "androidx.test:rules", version = "1.7.0" }
 androidx-test-runner = { module = "androidx.test:runner", version = "1.7.0" }
 androidx-webkit = { module = "androidx.webkit:webkit", version = "1.16.0" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/test-resources/build.gradle.kts
+++ b/test-resources/build.gradle.kts
@@ -10,6 +10,8 @@ android {
 }
 
 tasks.register("updateTestFiles") {
+  description = "Updates the test JSON files with fresh data from the Tenor API."
+
   // Resolve the output dir at configuration time so the doLast lambda captures only a
   // File (configuration-cache safe), not the Project via android.sourceSets.
   val resourcesFolder = layout.projectDirectory.dir("src/main/resources").asFile

--- a/test-resources/build.gradle.kts
+++ b/test-resources/build.gradle.kts
@@ -10,13 +10,10 @@ android {
 }
 
 tasks.register("updateTestFiles") {
+  // Resolve the output dir at configuration time so the doLast lambda captures only a
+  // File (configuration-cache safe), not the Project via android.sourceSets.
+  val resourcesFolder = layout.projectDirectory.dir("src/main/resources").asFile
   doLast {
-    // test-shared/src/main/resources
-    val resourcesFolder =
-      android.sourceSets["main"]
-        .resources.srcDirs
-        .first()
-
     val testData =
       mapOf(
         // Show enough to emulate a filtered "search" for testing

--- a/test-resources/src/main/resources/robolectric.properties
+++ b/test-resources/src/main/resources/robolectric.properties
@@ -1,2 +1,0 @@
-# temporary workaround for robolectric issue
-#sdk=34


### PR DESCRIPTION
## What & why

Speed up CI and local builds and clear build warnings — **no app-behavior or test-coverage changes**.

**Measured locally:** build cache ~5× on clean builds, config cache ~2.5× on incremental builds, unit tests ~9% faster, instrumented tests ~1.9× faster. CI critical path estimated **~12 min → ~6.5 min**.

## CI — `.github/workflows/build.yml`
- **3 parallel jobs** (`checks` / `instrumentation` / `release`) instead of one serial job.
- `release` R8 build runs on PRs too (catches minify/proguard/shrink breakage *before* merge) but is off the critical path; the artifact upload stays master-only.
- Drop `org.gradle.daemon=false` + `kotlin.incremental=false` — let `setup-gradle` manage the daemon.
- Drop `cache: gradle` on `setup-java` (it was disabling `setup-gradle`'s caching) and add `cache-encryption-key` so the config cache persists across runs.
- Cache Robolectric `android-all` jars (~150 MB previously re-downloaded each run); merge the 4 pre-emulator Gradle steps; drop the redundant second `assembleDebug` and the standalone wrapper-validation step.
- Per-job least-privilege `permissions`; `concurrency` cancels superseded PR runs; versioned AVD cache key.

> ⚠️ **Action required:** add repo secret `GRADLE_ENCRYPTION_KEY` (`openssl rand -base64 16`). Without it, `setup-gradle` just skips config-cache persistence — no failure.

## Gradle / build scripts
- Enable `org.gradle.caching`, `org.gradle.configuration-cache`, `org.gradle.parallel` in `gradle.properties` (committed, so CI and all contributors benefit — not just local global config).
- Wrapper switched to the `-bin` distribution (~100 MB smaller).
- Remove `JavaCompile.isFork` (no hand-written Java — only KSP/Hilt-generated); config-cache-safe test fork count (`availableProcessors()` rather than `gradle.startParameter`); fold the `JavaForkOptions` test-worker args into the `Test` block.
- Scope Compose/Paging opt-ins to `:app`; remove the redundant `allprojects { apply(ktlint) }`.
- Attach `mockito-core` as a `-javaagent` — JDK 21+ no longer allows the inline mock-maker to self-attach.

## Tests
- Remove the Android Test Orchestrator — the 8 instrumented tests pass in a shared process (verified on emulator); ~1.9× faster connected runs.
- Move pure-logic tests off Robolectric/Hilt to plain JUnit (DTO / entity / result tests). Room/DB/UI/service tests genuinely need Robolectric and are unchanged.

## Build warnings fixed
- Opt-in "unresolved marker" warnings in `:test-resources`.
- Manifest-merger `tools:replace` warning → `manifestPlaceholders` (debug → `DebugApplication`, release → `MainApplication`, unchanged behavior).

## Verified
`assembleDebug` / `lintDebug` / `testDebug` / `assembleRelease` / `connectedDebugAndroidTest` (on emulator) all green under configuration cache with **0 problems**; `build.yml` passes `actionlint`.
