### PR TITLE
fix: make Save to Gallery work (Glide asFile + DiskCacheStrategy.DATA)

### DIFF
--- a/app/src/androidTest/java/com/burrowsapps/gif/search/ui/giflist/GifScreenTest.kt
+++ b/app/src/androidTest/java/com/burrowsapps/gif/search/ui/giflist/GifScreenTest.kt
@@ -211,18 +211,13 @@ class GifScreenTest {
 
     val saved = runBlocking { saveGifToGallery(context = context, gifUrl = gifUrl) }
 
-    // Always clean up the MediaStore entry this test created, even if the assertion fails.
     deleteSavedGifs()
 
-    // Regression for the broken "Save to Gallery": before forcing DiskCacheStrategy.DATA,
-    // Glide.asFile() threw NoResultEncoderAvailableException (default strategy ALL has no File
-    // encoder), so saveGifToGallery always returned false and nothing was ever saved.
     assertThat(saved).isTrue()
   }
 
   @Test
   fun testSaveGifToGalleryReturnsFalseWhenDownloadFails() {
-    // The mock server answers any non-image path with 404, so Glide cannot produce a file.
     val missingUrl = "$MOCK_SERVER_URL/does-not-exist"
 
     val saved = runBlocking { saveGifToGallery(context = context, gifUrl = missingUrl) }

--- a/app/src/androidTest/java/com/burrowsapps/gif/search/ui/giflist/GifScreenTest.kt
+++ b/app/src/androidTest/java/com/burrowsapps/gif/search/ui/giflist/GifScreenTest.kt
@@ -2,6 +2,7 @@ package com.burrowsapps.gif.search.ui.giflist
 
 import android.content.ClipboardManager
 import android.content.Context
+import android.provider.MediaStore
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.isDialog
@@ -18,6 +19,7 @@ import com.burrowsapps.gif.search.R
 import com.burrowsapps.gif.search.di.ApiConfigModule
 import com.burrowsapps.gif.search.di.AppConfigModule
 import com.burrowsapps.gif.search.test.TestFileUtils.MOCK_SERVER_PORT
+import com.burrowsapps.gif.search.test.TestFileUtils.MOCK_SERVER_URL
 import com.burrowsapps.gif.search.test.TestFileUtils.getMockGifResponse
 import com.burrowsapps.gif.search.test.TestFileUtils.getMockResponse
 import com.burrowsapps.gif.search.test.onBackPressed
@@ -27,6 +29,7 @@ import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.HiltTestApplication
 import dagger.hilt.android.testing.UninstallModules
+import kotlinx.coroutines.runBlocking
 import leakcanary.DetectLeaksAfterTestSuccess
 import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
@@ -203,6 +206,33 @@ class GifScreenTest {
   }
 
   @Test
+  fun testSaveGifToGalleryReturnsTrueOnSuccess() {
+    val gifUrl = "$MOCK_SERVER_URL/save-to-gallery-test.gif"
+
+    val saved = runBlocking { saveGifToGallery(context = context, gifUrl = gifUrl) }
+
+    // Always clean up the MediaStore entry this test created, even if the assertion fails.
+    deleteSavedGifs()
+
+    // Regression for the broken "Save to Gallery": before forcing DiskCacheStrategy.DATA,
+    // Glide.asFile() threw NoResultEncoderAvailableException (default strategy ALL has no File
+    // encoder), so saveGifToGallery always returned false and nothing was ever saved.
+    assertThat(saved).isTrue()
+  }
+
+  @Test
+  fun testSaveGifToGalleryReturnsFalseWhenDownloadFails() {
+    // The mock server answers any non-image path with 404, so Glide cannot produce a file.
+    val missingUrl = "$MOCK_SERVER_URL/does-not-exist"
+
+    val saved = runBlocking { saveGifToGallery(context = context, gifUrl = missingUrl) }
+
+    deleteSavedGifs()
+
+    assertThat(saved).isFalse()
+  }
+
+  @Test
   fun testSearchAndCancelViaHardwareBackButton() {
     enterSearchMode()
 
@@ -257,5 +287,14 @@ class GifScreenTest {
     composeTestRule.onNode(hasSetTextAction()).performTextInput(searchText)
     composeTestRule.mainClock.advanceTimeByFrame()
     composeTestRule.waitForIdle()
+  }
+
+  /** Removes any GIFs this test wrote to the shared gallery (Pictures/GIF Search). */
+  private fun deleteSavedGifs() {
+    context.contentResolver.delete(
+      MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+      "${MediaStore.Images.Media.RELATIVE_PATH} LIKE ?",
+      arrayOf("Pictures/GIF Search%"),
+    )
   }
 }

--- a/app/src/main/java/com/burrowsapps/gif/search/ui/giflist/GifScreen.kt
+++ b/app/src/main/java/com/burrowsapps/gif/search/ui/giflist/GifScreen.kt
@@ -73,6 +73,7 @@ import androidx.paging.compose.itemContentType
 import androidx.paging.compose.itemKey
 import com.bumptech.glide.Glide
 import com.bumptech.glide.RequestBuilder
+import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.bumptech.glide.load.resource.gif.GifDrawable
 import com.bumptech.glide.request.target.Target
 import com.bumptech.glide.signature.ObjectKey
@@ -431,18 +432,22 @@ private fun GifDialog(
  * the GIF was already loaded for display), then writes it to Pictures/GIF Search/.
  * No WRITE_EXTERNAL_STORAGE permission required on Android 10+ (API 29+).
  */
-private suspend fun saveGifToGallery(
+internal suspend fun saveGifToGallery(
   context: Context,
   gifUrl: String,
 ): Boolean =
   withContext(Dispatchers.IO) {
     try {
-      // Fetch from Glide — likely already in disk cache from being displayed
+      // Fetch the raw GIF bytes from Glide — likely already in disk cache from being displayed.
+      // asFile() must use DiskCacheStrategy.DATA (or NONE): the module's default strategy is ALL,
+      // which has no result encoder for File and makes submit().get() throw
+      // NoResultEncoderAvailableException, so saving would always fail.
       val file =
         Glide
           .with(context.applicationContext)
           .asFile()
           .load(gifUrl)
+          .diskCacheStrategy(DiskCacheStrategy.DATA)
           .submit()
           .get()
       val values =

--- a/app/src/main/java/com/burrowsapps/gif/search/ui/giflist/GifScreen.kt
+++ b/app/src/main/java/com/burrowsapps/gif/search/ui/giflist/GifScreen.kt
@@ -438,10 +438,6 @@ internal suspend fun saveGifToGallery(
 ): Boolean =
   withContext(Dispatchers.IO) {
     try {
-      // Fetch the raw GIF bytes from Glide — likely already in disk cache from being displayed.
-      // asFile() must use DiskCacheStrategy.DATA (or NONE): the module's default strategy is ALL,
-      // which has no result encoder for File and makes submit().get() throw
-      // NoResultEncoderAvailableException, so saving would always fail.
       val file =
         Glide
           .with(context.applicationContext)


### PR DESCRIPTION
## Problem

**"Save to Gallery" never works** — every attempt shows the *"Failed to save GIF"* snackbar and nothing is written to `Pictures/GIF Search/`.

Confirmed on an emulator (API 36). Logcat on every tap:

```
W/Glide: GlideException: Failed to load resource
com.bumptech.glide.Registry$NoResultEncoderAvailableException:
  Failed to find result encoder for resource class: class java.io.File,
  you may need to consider ... DiskCacheStrategy.DATA/DiskCacheStrategy.NONE ...
```

## Root cause

`saveGifToGallery()` calls `Glide…asFile().load(gifUrl).submit().get()`. That request inherits the module-wide default set in `GlideModule` (`diskCacheStrategy(ALL)`). `asFile()` is incompatible with `ALL` — Glide has no result encoder for `java.io.File` — so `submit().get()` throws `NoResultEncoderAvailableException`. The surrounding `catch (_: Exception)` swallows it and the function always returns `false`, so the feature is 100% broken.

## Fix

Force `DiskCacheStrategy.DATA` on the `asFile()` request so Glide returns the raw downloaded file:

```kotlin
Glide.with(context.applicationContext)
  .asFile()
  .load(gifUrl)
  .diskCacheStrategy(DiskCacheStrategy.DATA) // asFile() needs DATA/NONE; default ALL has no File encoder
  .submit()
  .get()
```

`saveGifToGallery` is also made `internal` so it can be covered directly by instrumented tests.

## Tests

Added to `GifScreenTest` (instrumented, MockWebServer-backed):

- **`testSaveGifToGalleryReturnsTrueOnSuccess`** — valid GIF URL → `true`. This **fails before the fix** (the `asFile()` exception path) and passes after, locking the regression.
- **`testSaveGifToGalleryReturnsFalseWhenDownloadFails`** — a `404` URL → `false`, verifying error handling.

Both clean up the MediaStore entry they create.

```
$ ./gradlew :app:connectedDebugAndroidTest \
    -Pandroid.testInstrumentationRunnerArguments.class=...GifScreenTest#testSaveGifToGalleryReturnsTrueOnSuccess,...#testSaveGifToGalleryReturnsFalseWhenDownloadFails
Starting 2 tests on Pixel_9_Pro_XL(AVD) - 16
Finished 2 tests on Pixel_9_Pro_XL(AVD) - 16
BUILD SUCCESSFUL
```

## Scope / follow-ups

Focused on making saves work. Separate, related hardening for `saveGifToGallery` is intentionally **not** included here and can follow up: use `IS_PENDING` during the write, `delete(uri)` the orphaned row on failure, treat a null `openOutputStream` as failure (today it returns `true`), and log instead of swallowing the exception.