### PR TITLE
fix: enable StrictMode VmPolicy death (except the unfixable WebView config-change violation)

### DIFF
--- a/app/src/debug/java/com/burrowsapps/gif/search/DebugApplication.kt
+++ b/app/src/debug/java/com/burrowsapps/gif/search/DebugApplication.kt
@@ -18,13 +18,28 @@ class DebugApplication : MainApplication() {
         .penaltyDeath()
         .build(),
     )
+    // This is detectAll() minus detectIncorrectContextUse(). Once the license screen's WebView is
+    // created, WebView/Chromium registers an application-scoped ComponentCallbacks that reads
+    // ViewConfiguration from a non-UI context on every configuration change, raising an
+    // IncorrectContextUseViolation (https://issuetracker.google.com/issues/296928070). That is not
+    // fixable from app code and would kill penaltyDeath() on rotation, so it is the only detector
+    // left off; everything else is fatal.
     StrictMode.setVmPolicy(
       StrictMode.VmPolicy
         .Builder()
-        .detectAll()
+        .detectActivityLeaks()
+        .detectLeakedClosableObjects()
+        .detectLeakedRegistrationObjects()
+        .detectLeakedSqlLiteObjects()
+        .detectContentUriWithoutPermission()
+        .detectFileUriExposure()
+        .detectCleartextNetwork()
+        .detectUntaggedSockets()
+        .detectCredentialProtectedWhileLocked()
+        .detectImplicitDirectBoot()
+        .detectUnsafeIntentLaunch()
         .penaltyLog()
-        // TODO: go back from license page
-//        .penaltyDeath()
+        .penaltyDeath()
         .build(),
     )
   }

--- a/app/src/debug/java/com/burrowsapps/gif/search/DebugApplication.kt
+++ b/app/src/debug/java/com/burrowsapps/gif/search/DebugApplication.kt
@@ -1,6 +1,8 @@
 package com.burrowsapps.gif.search
 
 import android.os.StrictMode
+import android.os.strictmode.IncorrectContextUseViolation
+import android.os.strictmode.Violation
 import timber.log.Timber
 import timber.log.Timber.DebugTree
 
@@ -18,29 +20,31 @@ class DebugApplication : MainApplication() {
         .penaltyDeath()
         .build(),
     )
-    // This is detectAll() minus detectIncorrectContextUse(). Once the license screen's WebView is
-    // created, WebView/Chromium registers an application-scoped ComponentCallbacks that reads
-    // ViewConfiguration from a non-UI context on every configuration change, raising an
-    // IncorrectContextUseViolation (https://issuetracker.google.com/issues/296928070). That is not
-    // fixable from app code and would kill penaltyDeath() on rotation, so it is the only detector
-    // left off; everything else is fatal.
+    // VmPolicy can't use penaltyDeath() directly (and there is no detectAll()-minus-one API): once
+    // the license screen's WebView is created, WebView/Chromium raises an IncorrectContextUseViolation
+    // from an application-scoped callback on every configuration change. Keep detectAll() + log, and
+    // crash on every violation via penaltyListener EXCEPT that one framework issue (see isFatalViolation).
     StrictMode.setVmPolicy(
       StrictMode.VmPolicy
         .Builder()
-        .detectActivityLeaks()
-        .detectLeakedClosableObjects()
-        .detectLeakedRegistrationObjects()
-        .detectLeakedSqlLiteObjects()
-        .detectContentUriWithoutPermission()
-        .detectFileUriExposure()
-        .detectCleartextNetwork()
-        .detectUntaggedSockets()
-        .detectCredentialProtectedWhileLocked()
-        .detectImplicitDirectBoot()
-        .detectUnsafeIntentLaunch()
+        .detectAll()
         .penaltyLog()
-        .penaltyDeath()
-        .build(),
+        .penaltyListener(mainExecutor) { violation ->
+          if (isFatalViolation(violation)) throw violation
+        }.build(),
     )
+  }
+
+  internal companion object {
+    /**
+     * Whether a [Violation] should crash the debug build (the penaltyDeath() equivalent).
+     *
+     * Every VmPolicy violation is fatal except [IncorrectContextUseViolation]. Once the license
+     * screen's WebView exists, WebView/Chromium registers an application-scoped ComponentCallbacks
+     * that reads ViewConfiguration from a non-UI context on every configuration change; that fires
+     * on rotation, is not fixable from app code (https://issuetracker.google.com/issues/296928070),
+     * and so is logged rather than fatal.
+     */
+    internal fun isFatalViolation(violation: Violation): Boolean = violation !is IncorrectContextUseViolation
   }
 }

--- a/app/src/testDebug/java/com/burrowsapps/gif/search/DebugApplicationTest.kt
+++ b/app/src/testDebug/java/com/burrowsapps/gif/search/DebugApplicationTest.kt
@@ -1,0 +1,29 @@
+package com.burrowsapps.gif.search
+
+import android.os.strictmode.IncorrectContextUseViolation
+import android.os.strictmode.LeakedClosableViolation
+import android.os.strictmode.UntaggedSocketViolation
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+
+@RunWith(AndroidJUnit4::class)
+class DebugApplicationTest {
+  @Test
+  fun incorrectContextUseViolationIsNotFatal() {
+    // WebView/Chromium triggers this on configuration changes (b/296928070); it must not crash.
+    assertThat(DebugApplication.isFatalViolation(mock<IncorrectContextUseViolation>())).isFalse()
+  }
+
+  @Test
+  fun leakedClosableViolationIsFatal() {
+    assertThat(DebugApplication.isFatalViolation(mock<LeakedClosableViolation>())).isTrue()
+  }
+
+  @Test
+  fun untaggedSocketViolationIsFatal() {
+    assertThat(DebugApplication.isFatalViolation(mock<UntaggedSocketViolation>())).isTrue()
+  }
+}


### PR DESCRIPTION
## Problem

The debug build shipped with `VmPolicy.penaltyDeath()` commented out:

```kotlin
.penaltyLog()
// TODO: go back from license page
//        .penaltyDeath()
```

So every `VmPolicy` violation (leaks, closables, untagged sockets, …) was only *logged*, never fatal.

## Root cause — not fixable on our side (verified on-device)

Enabling `penaltyDeath()` crashes when you open **Open Source Licenses** and then rotate:

```
IncorrectContextUseViolation: ViewConfiguration needs a proper configuration ...
  at android.view.ViewConfiguration.get(...)
  at WV.o13.onConfigurationChanged(chromium-SystemWebViewGoogle...)   <- Chromium
  at android.app.Application.onConfigurationChanged(...)
  Caused by: ... from a non-UI Context: WV.px
```

This is **WebView/Chromium, not app code**. Once any WebView is created, Chromium registers an *application-scoped, process-global* `ComponentCallbacks` that reads `ViewConfiguration` from its own non-UI context on every configuration change — [b/296928070](https://issuetracker.google.com/issues/296928070) (the same issue the `LicenseScreenTest`s already cite via `@SkipLeakDetection`).

I verified on-device that **no app-side change prevents the violation from being raised** — it fires identically with:
- plain `webView.destroy()`,
- detach-before-`destroy()` (`stopLoading()` + `removeView()` + `removeAllViews()` + `destroy()`), and
- `MutableContextWrapper` (Activity context while alive, swapped to app context on dispose).

## Fix

There is no `detectAll().permit…()` / "detectAll-minus-one" API on `VmPolicy.Builder`, so the choices are (a) hand-enumerate every detector except one, or (b) keep `detectAll()` and filter in a listener. This PR uses (b) — cleaner, full logging, no enumeration to maintain:

```kotlin
.detectAll()
.penaltyLog()
.penaltyListener(mainExecutor) { violation ->
  if (isFatalViolation(violation)) throw violation
}
```
```kotlin
internal fun isFatalViolation(violation: Violation): Boolean =
  violation !is IncorrectContextUseViolation
```

Net effect = `penaltyDeath` for **every** VmPolicy violation the app can actually act on; the one unfixable framework violation is logged, not fatal. `ThreadPolicy.penaltyDeath()` is unchanged; release builds are unaffected (StrictMode is debug-only).

## Tests

`isFatalViolation` is extracted so it can be unit-tested (`app/src/testDebug`, kept out of the release variant):

- `incorrectContextUseViolationIsNotFatal` -> `false`
- `leakedClosableViolationIsFatal` / `untaggedSocketViolationIsFatal` -> `true`

`./gradlew :app:testDebugUnitTest --tests "*DebugApplicationTest"` -> **BUILD SUCCESSFUL**

### On-device verification
- Licenses -> back -> rotate, and rotate **while on** the license screen: previously crashed; now survives, violation still logged (`penaltyLog`).
- Scroll / dialog / save / search: one stable process, no other violations, **0 POLICY_DEATH**.

## Notes
- Intentionally does **not** touch `LicenseScreen` — no WebView context/teardown change resolves the violation, so changing it would only add noise.
- The separate Activity/WebView **leak** behind the `@SkipLeakDetection` annotations is the same b/296928070 root and is left as a follow-up; this PR is scoped to making `penaltyDeath` usable.
