### PR TITLE
fix: correctness, performance, and cleanup fixes (paging cascade-delete, copy feedback, Glide sizing, mediator leak)

### DIFF
--- a/app/src/androidTest/java/com/burrowsapps/gif/search/di/TestDatabaseModule.kt
+++ b/app/src/androidTest/java/com/burrowsapps/gif/search/di/TestDatabaseModule.kt
@@ -1,0 +1,47 @@
+package com.burrowsapps.gif.search.di
+
+import android.content.Context
+import androidx.room.Room
+import com.burrowsapps.gif.search.data.db.AppDatabase
+import com.burrowsapps.gif.search.data.db.dao.GifDao
+import com.burrowsapps.gif.search.data.db.dao.QueryResultDao
+import com.burrowsapps.gif.search.data.db.dao.RemoteKeysDao
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import dagger.hilt.testing.TestInstallIn
+import javax.inject.Singleton
+
+/**
+ * Replaces the on-disk database with an in-memory one for instrumented tests.
+ *
+ * The real database persists across reinstalls, so data left by manually running the app (or a
+ * previous run) would survive into a test and shadow the MockWebServer fixtures via
+ * RemoteMediator.initialize()'s SKIP_INITIAL_REFRESH. An in-memory database starts empty every test
+ * process and is never written to disk, keeping tests deterministic.
+ */
+@Module
+@TestInstallIn(components = [SingletonComponent::class], replaces = [DatabaseModule::class])
+internal class TestDatabaseModule {
+  @Provides
+  @Singleton
+  fun provideDatabase(
+    @ApplicationContext context: Context,
+  ): AppDatabase =
+    Room
+      .inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+      .build()
+
+  @Provides
+  @Singleton
+  fun provideGifDao(db: AppDatabase): GifDao = db.gifDao()
+
+  @Provides
+  @Singleton
+  fun provideQueryResultDao(db: AppDatabase): QueryResultDao = db.queryResultDao()
+
+  @Provides
+  @Singleton
+  fun provideRemoteKeysDao(db: AppDatabase): RemoteKeysDao = db.remoteKeysDao()
+}

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -9,5 +9,16 @@
   <application
     android:icon="@mipmap/ic_launcher"
     android:networkSecurityConfig="@xml/debug_network_security_config"
-    android:usesCleartextTraffic="true" />
+    android:usesCleartextTraffic="true">
+    <activity
+      android:name=".MainActivity"
+      android:exported="true">
+      <!-- Expose MainActivity to the monkey/UI-exerciser in debug builds only (not in release). -->
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+
+        <category android:name="android.intent.category.MONKEY" />
+      </intent-filter>
+    </activity>
+  </application>
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,6 @@
     android:fullBackupContent="@xml/backup_rules"
     android:icon="@mipmap/ic_launcher"
     android:label="@string/app_name"
-    android:largeHeap="true"
     android:roundIcon="@mipmap/ic_launcher_round"
     android:supportsRtl="true"
     android:theme="@style/AppTheme">
@@ -26,7 +25,6 @@
         <action android:name="android.intent.action.MAIN" />
 
         <category android:name="android.intent.category.LAUNCHER" />
-        <category android:name="android.intent.category.MONKEY" />
       </intent-filter>
     </activity>
 

--- a/app/src/main/java/com/burrowsapps/gif/search/MainApplication.kt
+++ b/app/src/main/java/com/burrowsapps/gif/search/MainApplication.kt
@@ -4,11 +4,11 @@ import android.app.Application
 import dagger.hilt.android.HiltAndroidApp
 
 /**
- * The main application class for this app.
+ * The base application class for this app.
  *
- * This class is annotated with @HiltAndroidApp, which enables the Hilt dependency injection
- * framework for the entire app. It also extends the Application class, and overrides its onCreate()
- * method to set the default night mode and enable compatibility mode for vector drawables.
+ * Annotated with @HiltAndroidApp to generate the Hilt dependency-injection components for the whole
+ * app. It is left `open` so the debug build can subclass it (see DebugApplication) to plant Timber
+ * and install StrictMode.
  */
 @HiltAndroidApp
 open class MainApplication : Application()

--- a/app/src/main/java/com/burrowsapps/gif/search/data/db/dao/GifDao.kt
+++ b/app/src/main/java/com/burrowsapps/gif/search/data/db/dao/GifDao.kt
@@ -8,7 +8,10 @@ import com.burrowsapps.gif.search.data.db.entity.GifEntity
 
 @Dao
 internal interface GifDao {
-  @Insert(onConflict = OnConflictStrategy.REPLACE)
+  // IGNORE, not REPLACE: GIF content is immutable (keyed by its tinyGifUrl), and REPLACE compiles to
+  // DELETE+INSERT, which would cascade-delete every query_results row referencing the GIF across all
+  // searches (ON DELETE CASCADE), silently corrupting other queries' cached pages.
+  @Insert(onConflict = OnConflictStrategy.IGNORE)
   suspend fun upsertAll(items: List<GifEntity>)
 
   @Query("DELETE FROM gifs")

--- a/app/src/main/java/com/burrowsapps/gif/search/data/repository/GifRemoteMediator.kt
+++ b/app/src/main/java/com/burrowsapps/gif/search/data/repository/GifRemoteMediator.kt
@@ -14,7 +14,6 @@ import com.burrowsapps.gif.search.ui.giflist.GifImageInfo
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import timber.log.Timber
-import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 
 internal class GifRemoteMediator(
@@ -24,126 +23,36 @@ internal class GifRemoteMediator(
   private val dispatcher: CoroutineDispatcher,
 ) : RemoteMediator<Int, GifImageInfo>() {
   companion object {
-    /**
-     * Number of refreshes between cleanup operations.
-     *
-     * Why 5? Based on empirical analysis of user behavior and performance characteristics:
-     *
-     * 1. **User behavior patterns:**
-     *    - Average session: 10-20 pull-to-refreshes
-     *    - Value of 5 = 2-4 cleanups per session (optimal maintenance frequency)
-     *
-     * 2. **Performance impact:**
-     *    - Reduces cleanup calls by 80% compared to every refresh
-     *    - With LEFT JOIN optimization: ~10ms per cleanup (negligible)
-     *    - Heavy user (20 refreshes): 4 cleanups = 40ms total (imperceptible)
-     *
-     * 3. **Database growth control:**
-     *    - Limits orphan accumulation to ~5x normal query size
-     *    - Example: If each query caches 45 GIFs, max 225 orphans before cleanup
-     *    - Prevents unbounded growth while avoiding excessive cleanup overhead
-     *
-     * 4. **Alternative values considered:**
-     *    - 3: More frequent, slightly higher CPU usage, marginal benefit
-     *    - 10: Less overhead, but allows 2x more orphan accumulation
-     *    - 5: Sweet spot between cleanliness and performance
-     */
+    // Run orphan cleanup at most once every CLEANUP_INTERVAL refreshes (count-based throttling)...
     private const val CLEANUP_INTERVAL = 5
 
-    /**
-     * Track last cleanup time per query to implement time-based throttling.
-     *
-     * Key: query key (e.g., "cats", "dogs", "" for trending)
-     * Value: timestamp of last cleanup in milliseconds
-     *
-     * Thread-safety: Uses ConcurrentHashMap to allow safe concurrent access
-     * from multiple coroutines/threads without explicit synchronization.
-     */
-    private val lastCleanupTime = ConcurrentHashMap<String, Long>()
-
-    /**
-     * Minimum time between cleanups (5 minutes).
-     *
-     * Ensures cleanup runs at least every 5 minutes even if user doesn't
-     * pull-to-refresh frequently. Prevents database bloat in long sessions
-     * with infrequent refreshes (e.g., user leaves app open and scrolls).
-     */
+    // ...or once enough time has passed since the last cleanup (time-based throttling).
     private val MIN_CLEANUP_INTERVAL_MS = TimeUnit.MINUTES.toMillis(5)
-
-    /**
-     * Track refresh count per query to implement count-based throttling.
-     *
-     * Key: query key (e.g., "cats", "dogs", "" for trending)
-     * Value: number of refreshes for that specific query
-     *
-     * This is per-query (not global) to ensure each query gets consistent cleanup
-     * behavior regardless of other active queries.
-     *
-     * Thread-safety: Uses ConcurrentHashMap to allow safe concurrent access.
-     * Note: While the map itself is thread-safe, the increment operation
-     * (get-modify-put) uses compute() for atomic updates.
-     */
-    private val refreshCounters = ConcurrentHashMap<String, Int>()
   }
 
+  // Throttling state is per-mediator: each instance handles exactly one queryKey, and Paging invokes
+  // load() serially, so plain fields are safe. This replaces the previous companion-object
+  // ConcurrentHashMaps, which were keyed by every distinct search and never evicted, growing
+  // unbounded for the whole process lifetime.
+  private var refreshCount = 0
+  private var lastCleanupTime = 0L
+
   /**
-   * Determines whether cleanup should run based on throttling rules.
-   *
-   * Cleanup runs when:
-   * 1. Every Nth refresh for this specific query (count-based throttling)
-   * 2. At least MIN_CLEANUP_INTERVAL_MS has passed since last cleanup (time-based throttling)
-   *
-   * Both throttling mechanisms are per-query to ensure consistent cleanup behavior
-   * regardless of other active queries.
-   *
-   * This prevents performance issues on every refresh while still keeping the database clean.
-   *
-   * Thread-safety: Uses atomic compute() operations on ConcurrentHashMap to ensure
-   * increment operations are thread-safe even under concurrent access.
-   *
-   * Note: Counter is incremented regardless of whether cleanup runs, because we want
-   * to track refresh frequency. The timestamp is only updated after successful cleanup
-   * to ensure accurate time-based throttling.
+   * Whether orphan cleanup should run for this load. Counts every refresh and runs cleanup on every
+   * CLEANUP_INTERVAL-th refresh, or whenever at least MIN_CLEANUP_INTERVAL_MS has elapsed since the
+   * last successful cleanup. The counter advances on every refresh; the timestamp only advances when
+   * cleanup actually completes (see recordCleanupCompleted).
    */
   private fun shouldRunCleanup(): Boolean {
-    // Atomically increment counter for THIS query only
-    // compute() ensures get-modify-put is atomic even if multiple threads access simultaneously
-    val currentCount =
-      refreshCounters.compute(queryKey) { _, currentValue ->
-        (currentValue ?: 0) + 1
-      } ?: 1 // Fallback (should never happen, but defensive)
-
-    // Count-based throttling: Only run every CLEANUP_INTERVAL refreshes for this query
-    val shouldRunByCount = currentCount % CLEANUP_INTERVAL == 0
-
-    // Time-based throttling: Only run if enough time has passed
-    val currentTime = System.currentTimeMillis()
-    val lastTime = lastCleanupTime.getOrDefault(queryKey, 0L)
-    val shouldRunByTime = (currentTime - lastTime) >= MIN_CLEANUP_INTERVAL_MS
-
-    // Return true if either condition is met (timestamp updated after cleanup completes)
+    refreshCount++
+    val shouldRunByCount = refreshCount % CLEANUP_INTERVAL == 0
+    val shouldRunByTime = (System.currentTimeMillis() - lastCleanupTime) >= MIN_CLEANUP_INTERVAL_MS
     return shouldRunByCount || shouldRunByTime
   }
 
-  /**
-   * Records that cleanup has successfully completed for this query.
-   *
-   * Thread-safety: Uses ConcurrentHashMap.compute() to atomically update the timestamp,
-   * preventing race conditions where multiple threads might try to update simultaneously.
-   * While simple put() would be atomic for a single write, using compute() or putIfAbsent()
-   * ensures we always record a timestamp close to when cleanup actually ran, which is
-   * important for accurate time-based throttling.
-   *
-   * The race condition with simple put() is acceptable in practice (cleanup might run
-   * slightly more often than intended), but using compute() is more correct and documents
-   * the intent clearly.
-   */
+  /** Records that cleanup has successfully completed, resetting the time-based throttle. */
   private fun recordCleanupCompleted() {
-    val currentTime = System.currentTimeMillis()
-    // Use compute() to atomically update, documenting that we care about race-free updates
-    lastCleanupTime.compute(queryKey) { _, _ ->
-      currentTime
-    }
+    lastCleanupTime = System.currentTimeMillis()
   }
 
   override suspend fun initialize(): InitializeAction {

--- a/app/src/main/java/com/burrowsapps/gif/search/ui/giflist/GifScreen.kt
+++ b/app/src/main/java/com/burrowsapps/gif/search/ui/giflist/GifScreen.kt
@@ -84,6 +84,7 @@ import com.skydoves.landscapist.ImageOptions
 import com.skydoves.landscapist.glide.GlideImage
 import com.skydoves.landscapist.glide.GlideRequestType.GIF
 import com.skydoves.landscapist.glide.LocalGlideRequestBuilder
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -185,8 +186,11 @@ private fun TheContent(
     val gridState = rememberLazyGridState()
     val focusManager = LocalFocusManager.current
 
-    // Calculate cell size once, outside the items block
+    // Calculate sizes once, outside the items block
     val cellSizePx = with(LocalDensity.current) { GifCellSize.roundToPx() }
+    val dialogSizePx = with(LocalDensity.current) { GifDialogSize.roundToPx() }
+    // Scope tied to this screen, not the dialog, so clipboard/snackbar work survives dismissal
+    val coroutineScope = rememberCoroutineScope()
 
     LaunchedEffect(gridState) {
       snapshotFlow { gridState.isScrollInProgress }.collect { isScrolling ->
@@ -208,6 +212,7 @@ private fun TheContent(
           currentSelectedItem = currentSelectedItem.value,
           onDismiss = { openDialog.value = false },
           hostState = hostState,
+          coroutineScope = coroutineScope,
         )
       }
 
@@ -261,12 +266,9 @@ private fun TheContent(
                   .semantics {
                     contentDescription = gifImageContentDesc
                   }.clickable {
-                    // Preload full-size GIF before dialog opens for faster display
-                    Glide
-                      .with(context)
-                      .asGif()
-                      .load(item.gifUrl)
-                      .preload()
+                    // Warm Glide's cache with the exact request the dialog will use, so it shows
+                    // instantly and decodes at the dialog's size rather than full resolution.
+                    loadGif(context = context, imageUrl = item.gifUrl, size = dialogSizePx).preload()
                     openDialog.value = true
                     currentSelectedItem.value = item
                   },
@@ -274,11 +276,10 @@ private fun TheContent(
               // Remember Glide request, invalidate on URL, context, or size changes
               // Context changes on configuration change, cellSizePx changes on density change
               val requestBuilder =
-                remember(item.tinyGifUrl, item.tinyGifPreviewUrl, context, cellSizePx) {
+                remember(item.tinyGifUrl, context, cellSizePx) {
                   loadGif(
                     context = context,
                     imageUrl = item.tinyGifUrl,
-                    thumbnailUrl = item.tinyGifPreviewUrl,
                     size = cellSizePx,
                   )
                 }
@@ -319,12 +320,13 @@ private fun GifDialog(
   currentSelectedItem: GifImageInfo?,
   onDismiss: () -> Unit,
   hostState: SnackbarHostState,
+  coroutineScope: CoroutineScope,
 ) {
   if (currentSelectedItem == null) return
 
   val clipboardManager = LocalClipboard.current
   val context = LocalContext.current
-  val coroutineScope = rememberCoroutineScope()
+  val dialogSizePx = with(LocalDensity.current) { GifDialogSize.roundToPx() }
   val gifImageDialogContentDesc = stringResource(R.string.gif_image_dialog_content_description)
   val copiedToClipboardMsg = stringResource(R.string.copied_to_clipboard)
   val copyUrlText = stringResource(R.string.copy_url)
@@ -357,11 +359,11 @@ private fun GifDialog(
       ) {
         // Memoized so the RequestBuilder is not recreated on every recomposition
         val requestBuilder =
-          remember(currentSelectedItem.gifUrl, currentSelectedItem.gifPreviewUrl, context) {
+          remember(currentSelectedItem.gifUrl, context, dialogSizePx) {
             loadGif(
               context = context,
               imageUrl = currentSelectedItem.gifUrl,
-              thumbnailUrl = currentSelectedItem.gifPreviewUrl,
+              size = dialogSizePx,
             )
           }
 
@@ -466,25 +468,18 @@ internal suspend fun saveGifToGallery(
     }
   }
 
+// Landscapist applies this builder via .apply(BaseRequestOptions), which keeps override/signature/
+// dontTransform but drops .thumbnail(), so a progressive thumbnail here would be dead code. Use the
+// size to downsample instead of decoding at full resolution.
 private fun loadGif(
   context: Context,
   imageUrl: String,
-  thumbnailUrl: String,
   size: Int = Target.SIZE_ORIGINAL,
-): RequestBuilder<GifDrawable> {
-  val request = Glide.with(context).asGif()
-  val thumbnailRequest =
-    request
-      .load(thumbnailUrl)
-      .override(size)
-      .dontTransform()
-      .signature(ObjectKey(thumbnailUrl))
-  val imageRequest =
-    request
-      .load(imageUrl)
-      .thumbnail(thumbnailRequest)
-      .override(size)
-      .dontTransform()
-      .signature(ObjectKey(imageUrl))
-  return imageRequest
-}
+): RequestBuilder<GifDrawable> =
+  Glide
+    .with(context)
+    .asGif()
+    .load(imageUrl)
+    .override(size)
+    .dontTransform()
+    .signature(ObjectKey(imageUrl))

--- a/app/src/test/java/com/burrowsapps/gif/search/data/db/dao/GifDaoTest.kt
+++ b/app/src/test/java/com/burrowsapps/gif/search/data/db/dao/GifDaoTest.kt
@@ -40,9 +40,12 @@ class GifDaoTest {
       dao.upsertAll(listOf(entity, entity2))
       assertThat(dao.count()).isEqualTo(2)
 
+      // IGNORE strategy: re-inserting an existing GIF (same tinyGifUrl) keeps the original row,
+      // it does not replace it (which would cascade-delete dependent query_results rows).
       val updated = entity2.copy(gifPreviewUrl = "changed")
       dao.upsertAll(listOf(updated))
-      assertThat(dao.getById("tiny2")?.gifPreviewUrl).isEqualTo("changed")
+      assertThat(dao.getById("tiny2")?.gifPreviewUrl).isEqualTo("gifPrev2")
+      assertThat(dao.count()).isEqualTo(2)
 
       dao.clearAll()
       assertThat(dao.count()).isEqualTo(0)

--- a/app/src/test/java/com/burrowsapps/gif/search/data/db/dao/QueryResultDaoTest.kt
+++ b/app/src/test/java/com/burrowsapps/gif/search/data/db/dao/QueryResultDaoTest.kt
@@ -117,4 +117,26 @@ class QueryResultDaoTest {
       val remain = dao.allForQuery("")
       assertThat(remain).isEmpty()
     }
+
+  @Test
+  fun reinsertingExistingGif_keepsMappingsAcrossQueries() =
+    runBlocking {
+      val gif = GifEntity("shared", "p", "g", "gp")
+      db.gifDao().upsertAll(listOf(gif))
+      // The same GIF is referenced by two different searches.
+      dao.insertAll(
+        listOf(
+          QueryResultEntity("", "shared", 0),
+          QueryResultEntity("cats", "shared", 0),
+        ),
+      )
+
+      // The GIF reappears (later page / another search) and is re-inserted. With IGNORE this is a
+      // no-op; with REPLACE it would DELETE+INSERT the gifs row and cascade-delete both mappings.
+      db.gifDao().upsertAll(listOf(gif.copy(gifUrl = "changed")))
+
+      assertThat(dao.allForQuery("")).hasSize(1)
+      assertThat(dao.allForQuery("cats")).hasSize(1)
+      assertThat(db.gifDao().count()).isEqualTo(1)
+    }
 }


### PR DESCRIPTION
A batch of independent correctness, performance, and cleanup fixes from a bug audit. All verified on an emulator (API 36): unit 95/95, instrumented 10/10, builds clean.

## Correctness

**Cross-query cache corruption (data loss)** — `GifDao.upsertAll` used `@Insert(onConflict = REPLACE)`. In SQLite that's `INSERT OR REPLACE` = DELETE+INSERT, and `query_results.gifId` has `ON DELETE CASCADE`, so re-inserting an already-cached GIF (e.g. a trending GIF that also appears in a search) **cascade-deletes that GIF's `query_results` rows across every search**, silently dropping items from other queries' cached pages. Switched to `IGNORE` (GIF content is immutable by URL).

**Copy-URL gave no feedback** — the Copy button called `onDismiss()` and then launched the clipboard + snackbar work on the dialog's `rememberCoroutineScope`, which is cancelled the moment the dialog leaves composition — so the "Copied to clipboard" snackbar never showed (pre-Android-13, no feedback at all). Now launched on a screen-scoped coroutine that outlives the dialog.

## Performance

**Dead progressive-thumbnail code + full-res decodes** — `loadGif` chained `.thumbnail(...)`, but Landscapist applies the builder via `.apply(BaseRequestOptions)`, which drops `.thumbnail()` — so it was dead allocation. Removed it, and the dialog/tap-preload now decode at the dialog's pixel size instead of `Target.SIZE_ORIGINAL`. The tap-preload now reuses the dialog's exact request (same size/signature) so it actually warms the cache instead of being wasted work.

**Unbounded process-lifetime growth** — `GifRemoteMediator` kept cleanup-throttling state in `companion object` `ConcurrentHashMap`s keyed by every distinct search and never evicted (they outlive the ViewModel/Pager for the whole process). Each mediator only ever handles one query and Paging calls `load()` serially, so these are now plain per-instance fields (also −110 lines of over-documentation).

## Cleanup

- Removed `android:largeHeap="true"` (Glide already manages its bitmap pool/caches; largeHeap just lengthens GC pauses and masks pressure).
- Moved `android.intent.category.MONKEY` out of the **release** manifest into the **debug** manifest only (verified in the merged manifests: debug keeps it with no duplicate launcher filter; release excludes it).
- Fixed `MainApplication`'s stale KDoc (claimed night-mode/vector setup it never did).

## Tests

- **New** `QueryResultDaoTest.reinsertingExistingGif_keepsMappingsAcrossQueries` — a shared GIF re-inserted keeps both queries' mappings (fails under `REPLACE`, passes under `IGNORE`).
- `GifDaoTest` updated to assert IGNORE semantics.
- **New** `TestDatabaseModule` (`@TestInstallIn` replacing `DatabaseModule`) gives instrumented tests an **in-memory** DB. The on-disk DB persists across reinstalls, so data from running the app by hand could shadow the MockWebServer fixtures via `SKIP_INITIAL_REFRESH` and flake the tests. Verified: the suite now passes even against a deliberately-polluted on-disk DB.

## Scope
Deliberately excludes: Save-robustness (overlaps #1291), cache-staleness + DB migration (needs a schema bump), WebView teardown, and the intentional `minSdk`.
