### PR TITLE
Remove deprecated android.newDsl from gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,3 @@ org.gradle.caching=true
 org.gradle.configuration-cache=true
 org.gradle.configuration-cache.parallel=true
 org.gradle.parallel=true
-
-# Required by legacy plugins (dexcount/license) that still use AGP's old AppExtension DSL.
-# AGP 9 deprecates this flag; keep it until those plugins migrate to the new DSL.
-android.newDsl=false


### PR DESCRIPTION
Removed deprecated android.newDsl property.