### PR TITLE
more optimizations

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -90,6 +90,12 @@ android {
         getDefaultProguardFile("proguard-android-optimize.txt"),
         rootDir.resolve("config/proguard/proguard-rules.txt"),
       )
+      if (!hasKeyPath) {
+        logger.warn(
+          "APP_KEYS_PATH is not set: signing the release build with the committed public debug " +
+            "keystore. This artifact must not be distributed.",
+        )
+      }
       signingConfig = signingConfigs.getByName(if (hasKeyPath) "release" else "debug")
     }
   }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
 
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-  <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
   <application
     android:name="${applicationName}"

--- a/app/src/main/java/com/burrowsapps/gif/search/data/db/AppDatabase.kt
+++ b/app/src/main/java/com/burrowsapps/gif/search/data/db/AppDatabase.kt
@@ -9,9 +9,11 @@ import com.burrowsapps.gif.search.data.db.entity.GifEntity
 import com.burrowsapps.gif.search.data.db.entity.QueryResultEntity
 import com.burrowsapps.gif.search.data.db.entity.RemoteKeysEntity
 
+// version 2: added RemoteKeysEntity.lastUpdated. No migration is registered; DatabaseModule enables
+// destructive migration, which is fine because this DB is a fully re-fetchable network cache.
 @Database(
   entities = [GifEntity::class, QueryResultEntity::class, RemoteKeysEntity::class],
-  version = 1,
+  version = 2,
   exportSchema = false,
 )
 internal abstract class AppDatabase : RoomDatabase() {

--- a/app/src/main/java/com/burrowsapps/gif/search/data/db/dao/QueryResultDao.kt
+++ b/app/src/main/java/com/burrowsapps/gif/search/data/db/dao/QueryResultDao.kt
@@ -11,9 +11,10 @@ import com.burrowsapps.gif.search.ui.giflist.GifImageInfo
 
 @Dao
 internal interface QueryResultDao {
-  // Keep first-seen ordering stable by ignoring duplicates
+  // Keep first-seen ordering stable by ignoring duplicates. Returns the inserted row ids (-1 for a
+  // row that was ignored as a duplicate) so callers can tell how many new rows actually landed.
   @Insert(onConflict = OnConflictStrategy.IGNORE)
-  suspend fun insertAll(items: List<QueryResultEntity>)
+  suspend fun insertAll(items: List<QueryResultEntity>): List<Long>
 
   @Query("DELETE FROM query_results WHERE searchKey = :searchKey")
   suspend fun clearQuery(searchKey: String)

--- a/app/src/main/java/com/burrowsapps/gif/search/data/db/dao/QueryResultDao.kt
+++ b/app/src/main/java/com/burrowsapps/gif/search/data/db/dao/QueryResultDao.kt
@@ -19,6 +19,25 @@ internal interface QueryResultDao {
   @Query("DELETE FROM query_results WHERE searchKey = :searchKey")
   suspend fun clearQuery(searchKey: String)
 
+  // Evicts cached result rows for any search whose last fetch (remote_keys.lastUpdated) predates
+  // [cutoff], except [exceptKey] (the query currently loading). Without this, every distinct search
+  // a user ever runs lingers in the DB forever, since clearQuery only ever targets the active query.
+  // GIFs left unreferenced by this delete are reclaimed by GifDao.deleteOrphanedGifs(). Returns the
+  // number of rows removed.
+  @Query(
+    """
+    DELETE FROM query_results
+    WHERE searchKey IN (
+      SELECT searchKey FROM remote_keys
+      WHERE searchKey != :exceptKey AND lastUpdated < :cutoff
+    )
+    """,
+  )
+  suspend fun clearStaleQueries(
+    cutoff: Long,
+    exceptKey: String,
+  ): Int
+
   @Query("SELECT COALESCE(MAX(position) + 1, 0) FROM query_results WHERE searchKey = :searchKey")
   suspend fun nextPositionForQuery(searchKey: String): Long
 

--- a/app/src/main/java/com/burrowsapps/gif/search/data/db/dao/RemoteKeysDao.kt
+++ b/app/src/main/java/com/burrowsapps/gif/search/data/db/dao/RemoteKeysDao.kt
@@ -16,4 +16,12 @@ internal interface RemoteKeysDao {
 
   @Query("DELETE FROM remote_keys WHERE searchKey = :searchKey")
   suspend fun clearQuery(searchKey: String)
+
+  // Companion to QueryResultDao.clearStaleQueries: drops the cursor rows for the same stale searches
+  // so remote_keys doesn't grow unbounded either. Skips [exceptKey] (the query currently loading).
+  @Query("DELETE FROM remote_keys WHERE searchKey != :exceptKey AND lastUpdated < :cutoff")
+  suspend fun clearStale(
+    cutoff: Long,
+    exceptKey: String,
+  ): Int
 }

--- a/app/src/main/java/com/burrowsapps/gif/search/data/db/entity/RemoteKeysEntity.kt
+++ b/app/src/main/java/com/burrowsapps/gif/search/data/db/entity/RemoteKeysEntity.kt
@@ -7,4 +7,6 @@ import androidx.room.PrimaryKey
 internal data class RemoteKeysEntity(
   @PrimaryKey val searchKey: String,
   val nextKey: String?,
+  // Wall-clock time of the last successful fetch for this query; used by the staleness/TTL check.
+  val lastUpdated: Long = 0L,
 )

--- a/app/src/main/java/com/burrowsapps/gif/search/data/repository/GifRemoteMediator.kt
+++ b/app/src/main/java/com/burrowsapps/gif/search/data/repository/GifRemoteMediator.kt
@@ -28,6 +28,9 @@ internal class GifRemoteMediator(
 
     // ...or once enough time has passed since the last cleanup (time-based throttling).
     private val MIN_CLEANUP_INTERVAL_MS = TimeUnit.MINUTES.toMillis(5)
+
+    // Cached results older than this are considered stale and trigger a refresh when the app reopens.
+    private val CACHE_TTL_MS = TimeUnit.HOURS.toMillis(1)
   }
 
   // Throttling state is per-mediator: each instance handles exactly one queryKey, and Paging invokes
@@ -35,7 +38,10 @@ internal class GifRemoteMediator(
   // ConcurrentHashMaps, which were keyed by every distinct search and never evicted, growing
   // unbounded for the whole process lifetime.
   private var refreshCount = 0
-  private var lastCleanupTime = 0L
+
+  // Initialized to "now" (not 0L) so a freshly constructed mediator is treated as "just cleaned":
+  // cleanup is gated by the count/time throttle instead of firing on the very first refresh.
+  private var lastCleanupTime = System.currentTimeMillis()
 
   /**
    * Whether orphan cleanup should run for this load. Counts every refresh and runs cleanup on every
@@ -56,11 +62,13 @@ internal class GifRemoteMediator(
   }
 
   override suspend fun initialize(): InitializeAction {
-    // Check if we have cached data for this query
-    // If yes, skip refresh to avoid flickering
-    // If no, launch initial refresh to fetch data
+    // Skip the initial network refresh only when cached rows exist AND are still fresh. Without a
+    // TTL, the trending feed (and every search) would stay frozen at its first fetch forever; with
+    // it, a stale cache triggers a refresh on app open while a fresh cache still avoids flicker.
     val hasData = database.queryResultDao().nextPositionForQuery(queryKey) > 0
-    return if (hasData) {
+    val lastUpdated = database.remoteKeysDao().remoteKeys(queryKey)?.lastUpdated ?: 0L
+    val isFresh = System.currentTimeMillis() - lastUpdated < CACHE_TTL_MS
+    return if (hasData && isFresh) {
       InitializeAction.SKIP_INITIAL_REFRESH
     } else {
       InitializeAction.LAUNCH_INITIAL_REFRESH
@@ -139,11 +147,13 @@ internal class GifRemoteMediator(
             response
               ?.next
               ?.takeIf { it.isNotBlank() && it != currentKey }
-          val isEndOfPagination = items.isEmpty() || nextCursor == null
+          // Mutable so an APPEND page that adds no new rows (all duplicates) can also end pagination.
+          var reachedEnd = items.isEmpty() || nextCursor == null
+          val fetchedAt = System.currentTimeMillis()
 
           Timber.d(
             "GifRemoteMediator: Loaded ${items.size} items, nextCursor=$nextCursor, " +
-              "endOfPagination=$isEndOfPagination",
+              "endOfPagination=$reachedEnd",
           )
 
           // Save everything to database in a single transaction for consistency
@@ -189,26 +199,35 @@ internal class GifRemoteMediator(
                 remoteKeysDao.clearQuery(queryKey)
               }
 
-              queryResultsDao.insertAll(mappings)
+              // insertAll uses IGNORE; already-seen (searchKey, gifId) rows are dropped (rowId -1).
+              // If an APPEND page is entirely duplicates, nothing new lands — end pagination so
+              // Paging doesn't keep fetching fresh cursors that never grow the list.
+              val insertedCount = queryResultsDao.insertAll(mappings).count { it != -1L }
+              if (loadType == LoadType.APPEND && insertedCount == 0) {
+                reachedEnd = true
+              }
 
-              Timber.d("GifRemoteMediator: Saved ${items.size} items starting at position $startPos")
+              Timber.d("GifRemoteMediator: Saved $insertedCount/${items.size} items from position $startPos")
             } else if (loadType == LoadType.REFRESH) {
               // If no items, still clear old data
               queryResultsDao.clearQuery(queryKey)
               remoteKeysDao.clearQuery(queryKey)
             }
 
-            // Step 5: Update remote keys with the next cursor for pagination
+            // Step 5: Store the next cursor (null once we've reached the end) plus a fetch timestamp
+            // that initialize() uses for its staleness/TTL check.
             remoteKeysDao.upsert(
               RemoteKeysEntity(
                 searchKey = queryKey,
-                nextKey = nextCursor,
+                nextKey = if (reachedEnd) null else nextCursor,
+                lastUpdated = fetchedAt,
               ),
             )
           }
 
-          // Cleanup orphaned GIFs asynchronously outside the transaction
-          // This runs in the background and doesn't block the user
+          // Cleanup orphaned GIFs outside the transaction, on the IO dispatcher (never the main
+          // thread). It runs inline, so it slightly delays this load()'s completion (and the refresh
+          // spinner); the committed rows are already pushed to the UI by Room before this runs.
           if (loadType == LoadType.REFRESH && shouldRunCleanup()) {
             withContext(dispatcher) {
               try {
@@ -236,7 +255,7 @@ internal class GifRemoteMediator(
             }
           }
 
-          MediatorResult.Success(endOfPaginationReached = isEndOfPagination)
+          MediatorResult.Success(endOfPaginationReached = reachedEnd)
         }
       }
     } catch (e: Exception) {

--- a/app/src/main/java/com/burrowsapps/gif/search/data/repository/GifRemoteMediator.kt
+++ b/app/src/main/java/com/burrowsapps/gif/search/data/repository/GifRemoteMediator.kt
@@ -31,6 +31,11 @@ internal class GifRemoteMediator(
 
     // Cached results older than this are considered stale and trigger a refresh when the app reopens.
     private val CACHE_TTL_MS = TimeUnit.HOURS.toMillis(1)
+
+    // Searches not revisited within this window are evicted from the DB cache to bound its growth.
+    // Much longer than CACHE_TTL_MS: TTL only decides when to re-fetch a query you're viewing now,
+    // whereas this decides when to forget a query you haven't returned to at all.
+    private val STALE_QUERY_RETENTION_MS = TimeUnit.DAYS.toMillis(7)
   }
 
   // Throttling state is per-mediator: each instance handles exactly one queryKey, and Paging invokes
@@ -39,15 +44,19 @@ internal class GifRemoteMediator(
   // unbounded for the whole process lifetime.
   private var refreshCount = 0
 
-  // Initialized to "now" (not 0L) so a freshly constructed mediator is treated as "just cleaned":
-  // cleanup is gated by the count/time throttle instead of firing on the very first refresh.
-  private var lastCleanupTime = System.currentTimeMillis()
+  // Initialized to 0L so the time-based arm fires on a fresh mediator's first refresh. Mediators
+  // are short-lived — one per query change and per process, usually performing a single refresh —
+  // so seeding this with "now" would leave cleanup (and the stale-query eviction it drives)
+  // essentially unreachable in real sessions: neither five refreshes nor five in-session minutes
+  // typically happen for one instance.
+  private var lastCleanupTime = 0L
 
   /**
-   * Whether orphan cleanup should run for this load. Counts every refresh and runs cleanup on every
-   * CLEANUP_INTERVAL-th refresh, or whenever at least MIN_CLEANUP_INTERVAL_MS has elapsed since the
-   * last successful cleanup. The counter advances on every refresh; the timestamp only advances when
-   * cleanup actually completes (see recordCleanupCompleted).
+   * Whether orphan cleanup should run for this load. Runs cleanup on a fresh instance's first
+   * refresh, then on every CLEANUP_INTERVAL-th refresh, or whenever at least
+   * MIN_CLEANUP_INTERVAL_MS has elapsed since the last successful cleanup. The counter advances on
+   * every refresh; the timestamp only advances when cleanup actually completes (see
+   * recordCleanupCompleted).
    */
   private fun shouldRunCleanup(): Boolean {
     refreshCount++
@@ -232,16 +241,29 @@ internal class GifRemoteMediator(
             withContext(dispatcher) {
               try {
                 val cleanupStartTime = System.currentTimeMillis()
+
+                // Evict caches for searches not refreshed within the retention window (skipping the
+                // active query, which we just refreshed). Dropping their query_results unreferences
+                // the GIFs they pointed at, which deleteOrphanedGifs() below then reclaims.
+                val staleCutoff = System.currentTimeMillis() - STALE_QUERY_RETENTION_MS
+                val evictedRows =
+                  database.withTransaction {
+                    val rows = queryResultsDao.clearStaleQueries(staleCutoff, queryKey)
+                    remoteKeysDao.clearStale(staleCutoff, queryKey)
+                    rows
+                  }
+
                 val orphanedCount = gifDao.deleteOrphanedGifs()
 
                 // Only record successful cleanup to ensure accurate throttling
                 // If cleanup fails, we'll retry on the next interval
                 recordCleanupCompleted()
 
-                if (orphanedCount > 0) {
+                if (orphanedCount > 0 || evictedRows > 0) {
                   Timber.d(
-                    "GifRemoteMediator: Cleaned up $orphanedCount orphaned GIF entities " +
-                      "for query='$queryKey' (took ${System.currentTimeMillis() - cleanupStartTime}ms)",
+                    "GifRemoteMediator: Cleaned up $orphanedCount orphaned GIF entities and " +
+                      "$evictedRows stale result rows for query='$queryKey' " +
+                      "(took ${System.currentTimeMillis() - cleanupStartTime}ms)",
                   )
                 }
               } catch (e: Exception) {

--- a/app/src/main/java/com/burrowsapps/gif/search/di/GlideModule.kt
+++ b/app/src/main/java/com/burrowsapps/gif/search/di/GlideModule.kt
@@ -62,12 +62,22 @@ internal class GlideModule : AppGlideModule() {
     glide: Glide,
     registry: Registry,
   ) {
-    val okHttpClient = getGlideEntryPoint(context).provideOkHttpClient()
+    // Reuse the app's OkHttpClient (so image fetches share its Dispatcher + ConnectionPool for
+    // connection reuse) but strip the HTTP disk cache. Glide already keeps its own source/result
+    // disk cache, so letting OkHttp cache image bytes too would (1) store every GIF on disk twice
+    // and (2) let large image responses evict the small Tenor API JSON that the shared 50 MiB cache
+    // exists to retain. newBuilder() shares the pools; cache(null) drops only the duplicate cache.
+    val imageClient =
+      getGlideEntryPoint(context)
+        .provideOkHttpClient()
+        .newBuilder()
+        .cache(null)
+        .build()
 
     registry.replace(
       GlideUrl::class.java,
       InputStream::class.java,
-      OkHttpUrlLoader.Factory(okHttpClient),
+      OkHttpUrlLoader.Factory(imageClient),
     )
   }
 

--- a/app/src/main/java/com/burrowsapps/gif/search/ui/giflist/GifScreen.kt
+++ b/app/src/main/java/com/burrowsapps/gif/search/ui/giflist/GifScreen.kt
@@ -4,6 +4,7 @@ import android.content.ClipData
 import android.content.ContentValues
 import android.content.Context
 import android.content.res.Configuration
+import android.net.Uri
 import android.provider.MediaStore
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
@@ -84,10 +85,13 @@ import com.skydoves.landscapist.ImageOptions
 import com.skydoves.landscapist.glide.GlideImage
 import com.skydoves.landscapist.glide.GlideRequestType.GIF
 import com.skydoves.landscapist.glide.LocalGlideRequestBuilder
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.withContext
+import timber.log.Timber
 
 // Grid cell size for GIF thumbnails
 private val GifCellSize: Dp = 135.dp
@@ -439,32 +443,49 @@ internal suspend fun saveGifToGallery(
   gifUrl: String,
 ): Boolean =
   withContext(Dispatchers.IO) {
+    val resolver = context.contentResolver
+    // asFile() must use DiskCacheStrategy.DATA (or NONE): the module default is ALL, which has no
+    // File encoder and would make get() throw NoResultEncoderAvailableException.
+    val futureTarget =
+      Glide
+        .with(context.applicationContext)
+        .asFile()
+        .load(gifUrl)
+        .diskCacheStrategy(DiskCacheStrategy.DATA)
+        .submit()
+    var uri: Uri? = null
     try {
-      val file =
-        Glide
-          .with(context.applicationContext)
-          .asFile()
-          .load(gifUrl)
-          .diskCacheStrategy(DiskCacheStrategy.DATA)
-          .submit()
-          .get()
+      // runInterruptible makes the blocking Future.get() cancellation-aware, so navigating away
+      // mid-save frees the IO worker instead of leaving it parked.
+      val file = runInterruptible { futureTarget.get() }
       val values =
         ContentValues().apply {
           put(MediaStore.Images.Media.DISPLAY_NAME, "gif_${System.currentTimeMillis()}.gif")
           put(MediaStore.Images.Media.MIME_TYPE, "image/gif")
           put(MediaStore.Images.Media.RELATIVE_PATH, "Pictures/GIF Search")
+          // Keep the entry hidden from the gallery/scanner until the bytes are fully written.
+          put(MediaStore.Images.Media.IS_PENDING, 1)
         }
-      val uri =
-        context.contentResolver.insert(
-          MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
-          values,
-        ) ?: return@withContext false
-      context.contentResolver.openOutputStream(uri)?.use { outputStream ->
-        file.inputStream().use { inputStream -> inputStream.copyTo(outputStream) }
-      }
+      uri =
+        resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values)
+          ?: return@withContext false
+      // A null output stream means nothing can be written — treat it as failure, not fake success.
+      val output = resolver.openOutputStream(uri) ?: error("openOutputStream returned null for $uri")
+      output.use { out -> file.inputStream().use { input -> input.copyTo(out) } }
+      // Publish the completed file to the gallery.
+      resolver.update(uri, ContentValues().apply { put(MediaStore.Images.Media.IS_PENDING, 0) }, null, null)
       true
-    } catch (_: Exception) {
+    } catch (e: CancellationException) {
+      // Cancelled (e.g. user left the screen) — remove the pending row and propagate.
+      uri?.let { runCatching { resolver.delete(it, null, null) } }
+      throw e
+    } catch (e: Exception) {
+      // On any failure, delete the half-written/empty row so no broken thumbnail is left behind.
+      uri?.let { runCatching { resolver.delete(it, null, null) } }
+      Timber.e(e, "saveGifToGallery failed for $gifUrl")
       false
+    } finally {
+      Glide.with(context.applicationContext).clear(futureTarget)
     }
   }
 

--- a/app/src/main/java/com/burrowsapps/gif/search/ui/giflist/GifScreen.kt
+++ b/app/src/main/java/com/burrowsapps/gif/search/ui/giflist/GifScreen.kt
@@ -77,12 +77,12 @@ import com.bumptech.glide.RequestBuilder
 import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.bumptech.glide.load.resource.gif.GifDrawable
 import com.bumptech.glide.request.target.Target
-import com.bumptech.glide.signature.ObjectKey
 import com.burrowsapps.gif.search.R
 import com.burrowsapps.gif.search.Screen
 import com.burrowsapps.gif.search.ui.theme.GifTheme
 import com.skydoves.landscapist.ImageOptions
 import com.skydoves.landscapist.glide.GlideImage
+import com.skydoves.landscapist.glide.GlideImageState
 import com.skydoves.landscapist.glide.GlideRequestType.GIF
 import com.skydoves.landscapist.glide.LocalGlideRequestBuilder
 import kotlinx.coroutines.CancellationException
@@ -98,6 +98,10 @@ private val GifCellSize: Dp = 135.dp
 
 // Full-size GIF dialog size
 private val GifDialogSize: Dp = 350.dp
+
+// Stable, shared image options. Hoisted so the ~20 simultaneously-recomposing grid cells (and the
+// dialog) reuse one instance instead of allocating a new ImageOptions on every recomposition.
+private val CropImageOptions = ImageOptions(contentScale = ContentScale.Crop)
 
 /** Shows the main screen of trending gifs. */
 @Preview(
@@ -193,6 +197,9 @@ private fun TheContent(
     // Calculate sizes once, outside the items block
     val cellSizePx = with(LocalDensity.current) { GifCellSize.roundToPx() }
     val dialogSizePx = with(LocalDensity.current) { GifDialogSize.roundToPx() }
+    // Resolve the per-cell content description once here rather than re-resolving it inside every
+    // grid item's composition (stringResource reads LocalContext/LocalConfiguration each call).
+    val gifImageContentDesc = stringResource(R.string.gif_image_content_description)
     // Scope tied to this screen, not the dialog, so clipboard/snackbar work survives dismissal
     val coroutineScope = rememberCoroutineScope()
 
@@ -263,7 +270,26 @@ private fun TheContent(
             contentType = pagingItems.itemContentType { "gif" },
           ) { index ->
             val item = pagingItems[index] ?: return@items
-            val gifImageContentDesc = stringResource(R.string.gif_image_content_description)
+            // Pause this cell's animation during active scroll/fling and while the full-size dialog
+            // is open; resume at rest. This trims the sustained cost of ~20 GIFs decoding at once.
+            // It is start()/stop() on the same drawable landscapist is already drawing — no reload,
+            // no model swap, so nothing flickers; the frame simply freezes and resumes in place.
+            // The states are read inside snapshotFlow (as with focus-clearing above), not in
+            // composition, so scroll flips, dialog toggles, and drawable delivery drive this side
+            // effect without recomposing every visible cell.
+            val gifDrawable = remember { mutableStateOf<GifDrawable?>(null) }
+            LaunchedEffect(Unit) {
+              snapshotFlow {
+                (!gridState.isScrollInProgress && !openDialog.value) to gifDrawable.value
+              }.collect { (shouldAnimate, drawable) ->
+                if (drawable == null) return@collect
+                if (shouldAnimate) {
+                  if (!drawable.isRunning) drawable.start()
+                } else if (drawable.isRunning) {
+                  drawable.stop()
+                }
+              }
+            }
             Box(
               modifier =
                 Modifier
@@ -292,12 +318,19 @@ private fun TheContent(
                 GlideImage(
                   imageModel = { item.tinyGifUrl },
                   glideRequestType = GIF,
+                  // Capture the decoded GifDrawable so the effect above can pause/resume it. For a
+                  // GIF request, Success.data is the GifDrawable landscapist renders.
+                  onImageStateChanged = { state ->
+                    if (state is GlideImageState.Success) {
+                      gifDrawable.value = state.data as? GifDrawable
+                    }
+                  },
                   modifier =
                     Modifier
                       .padding(1.dp)
                       .fillMaxWidth()
                       .size(GifCellSize),
-                  imageOptions = ImageOptions(contentScale = ContentScale.Crop),
+                  imageOptions = CropImageOptions,
                   loading = {
                     // Static placeholder to avoid per-cell animated spinners
                     Box(
@@ -380,7 +413,7 @@ private fun GifDialog(
                 .padding(1.dp)
                 .fillMaxWidth()
                 .size(GifDialogSize),
-            imageOptions = ImageOptions(contentScale = ContentScale.Crop),
+            imageOptions = CropImageOptions,
             loading = {
               Box(modifier = Modifier.matchParentSize()) {
                 CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
@@ -503,4 +536,5 @@ private fun loadGif(
     .load(imageUrl)
     .override(size)
     .dontTransform()
-    .signature(ObjectKey(imageUrl))
+// No .signature(ObjectKey(imageUrl)): imageUrl is already the load model and thus the cache key, so
+// signing with the same string adds nothing but an allocation and extra key hashing per request.

--- a/app/src/main/java/com/burrowsapps/gif/search/ui/giflist/GifViewModel.kt
+++ b/app/src/main/java/com/burrowsapps/gif/search/ui/giflist/GifViewModel.kt
@@ -34,7 +34,9 @@ internal class GifViewModel
 
     val gifPagingData: Flow<PagingData<GifImageInfo>> =
       searchText
-        .debounce(300) // Wait 300ms after user stops typing
+        // Debounce typed queries by 300ms, but let the initial/blank (trending) query through
+        // immediately so the first load isn't delayed by 300ms with nothing happening.
+        .debounce { query -> if (query.isBlank()) 0L else 300L }
         .map { query ->
           // Normalize the query: trim, lowercase, empty string for trending
           query

--- a/app/src/main/java/com/burrowsapps/gif/search/ui/license/LicenseScreen.kt
+++ b/app/src/main/java/com/burrowsapps/gif/search/ui/license/LicenseScreen.kt
@@ -2,12 +2,15 @@ package com.burrowsapps.gif.search.ui.license
 
 import android.content.Context
 import android.content.res.Configuration
+import android.view.ViewGroup
 import android.webkit.WebSettings
 import android.webkit.WebView
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.PlainTooltip
@@ -23,7 +26,9 @@ import androidx.compose.material3.rememberTooltipState
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
@@ -152,25 +157,46 @@ private fun TheWebView(assetLoader: WebViewAssetLoader) {
   val context = LocalContext.current
   val runningInPreview = LocalInspectionMode.current
 
+  // Build the WebView after the first frame so its one-time Chromium init doesn't jank the
+  // navigation transition into this screen. (WebView must still be constructed on the main thread.)
+  // Read into a plain val (not a `by` delegate) so DisposableEffect's onDispose captures this
+  // composition's value rather than re-reading live state (which would destroy the new instance).
   val webView =
-    remember {
-      configuredWebView(
-        context = context,
-        assetLoader = assetLoader,
-        runningInPreview = runningInPreview,
-      )
-    }
+    produceState<WebView?>(initialValue = null) {
+      value =
+        configuredWebView(
+          context = context,
+          assetLoader = assetLoader,
+          runningInPreview = runningInPreview,
+        )
+    }.value
 
   DisposableEffect(webView) {
-    onDispose { webView.destroy() }
+    onDispose {
+      webView?.let { view ->
+        // Tear down in the documented order: stop the load and detach from the view tree before
+        // destroy(), so Chromium isn't destroyed mid-load while still attached.
+        view.stopLoading()
+        (view.parent as? ViewGroup)?.removeView(view)
+        view.removeAllViews()
+        view.destroy()
+      }
+    }
   }
 
-  AndroidView(
-    factory = { webView },
-    modifier = Modifier.fillMaxSize(),
-  ) {
-    // from "main/assets/index.html" -> "file:///android_asset/index.html"
-    it.loadUrl("https://appassets.androidplatform.net/assets/open_source_licenses.html")
+  val view = webView
+  if (view == null) {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+      CircularProgressIndicator()
+    }
+  } else {
+    AndroidView(
+      factory = { view },
+      modifier = Modifier.fillMaxSize(),
+    ) {
+      // from "main/assets/index.html" -> "file:///android_asset/index.html"
+      it.loadUrl("https://appassets.androidplatform.net/assets/open_source_licenses.html")
+    }
   }
 }
 

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -6,8 +6,8 @@
    See https://developer.android.com/about/versions/12/backup-restore
 -->
 <full-backup-content>
-  <!--
- <include domain="sharedpref" path="."/>
- <exclude domain="sharedpref" path="device.xml"/>
--->
+  <!-- The Room "gif-db" is a fully re-fetchable network cache; exclude it from backup. -->
+  <exclude domain="database" path="gif-db"/>
+  <exclude domain="database" path="gif-db-wal"/>
+  <exclude domain="database" path="gif-db-shm"/>
 </full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -13,6 +13,12 @@
     <!-- Exclude caches and other transient files -->
     <exclude domain="file" path="cache/"/>
     <exclude domain="file" path="code_cache/"/>
+
+    <!-- The Room "gif-db" is a fully re-fetchable network cache; don't spend backup quota on it or
+         risk restoring a stale/inconsistent WAL snapshot. -->
+    <exclude domain="database" path="gif-db"/>
+    <exclude domain="database" path="gif-db-wal"/>
+    <exclude domain="database" path="gif-db-shm"/>
   </cloud-backup>
   <!--
   <device-transfer>

--- a/app/src/test/java/com/burrowsapps/gif/search/data/db/dao/QueryResultDaoTest.kt
+++ b/app/src/test/java/com/burrowsapps/gif/search/data/db/dao/QueryResultDaoTest.kt
@@ -6,6 +6,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.burrowsapps.gif.search.data.db.AppDatabase
 import com.burrowsapps.gif.search.data.db.entity.GifEntity
 import com.burrowsapps.gif.search.data.db.entity.QueryResultEntity
+import com.burrowsapps.gif.search.data.db.entity.RemoteKeysEntity
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.runBlocking
 import org.junit.After
@@ -116,6 +117,42 @@ class QueryResultDaoTest {
       db.gifDao().clearAll()
       val remain = dao.allForQuery("")
       assertThat(remain).isEmpty()
+    }
+
+  @Test
+  fun clearStaleQueries_removesOnlyStaleNonActiveQueries() =
+    runBlocking {
+      db.gifDao().upsertAll(
+        listOf(
+          GifEntity("f", "fp", "fg", "fgp"),
+          GifEntity("s", "sp", "sg", "sgp"),
+          GifEntity("a", "ap", "ag", "agp"),
+        ),
+      )
+      // Three searches: one fresh, one stale-but-active (the query loading now), one stale.
+      dao.insertAll(
+        listOf(
+          QueryResultEntity("fresh", "f", 0),
+          QueryResultEntity("active", "a", 0),
+          QueryResultEntity("stale", "s", 0),
+        ),
+      )
+      val now = 10_000_000L
+      val cutoff = now - 1_000L
+      db.remoteKeysDao().upsert(RemoteKeysEntity("fresh", nextKey = "1", lastUpdated = now))
+      db.remoteKeysDao().upsert(RemoteKeysEntity("active", nextKey = "1", lastUpdated = 0L))
+      db.remoteKeysDao().upsert(RemoteKeysEntity("stale", nextKey = "1", lastUpdated = 0L))
+
+      val removed = dao.clearStaleQueries(cutoff = cutoff, exceptKey = "active")
+
+      assertThat(removed).isEqualTo(1)
+      assertThat(dao.allForQuery("stale")).isEmpty()
+      // Fresh (recent) and active (excluded despite being stale) both survive.
+      assertThat(dao.allForQuery("fresh")).hasSize(1)
+      assertThat(dao.allForQuery("active")).hasSize(1)
+      // The stale GIF is now orphaned and reclaimable; the others remain referenced.
+      assertThat(db.gifDao().deleteOrphanedGifs()).isEqualTo(1)
+      assertThat(db.gifDao().count()).isEqualTo(2)
     }
 
   @Test

--- a/app/src/test/java/com/burrowsapps/gif/search/data/db/dao/RemoteKeysDaoTest.kt
+++ b/app/src/test/java/com/burrowsapps/gif/search/data/db/dao/RemoteKeysDaoTest.kt
@@ -44,4 +44,22 @@ class RemoteKeysDaoTest {
       dao.clearQuery(query)
       assertThat(dao.remoteKeys(query)).isNull()
     }
+
+  @Test
+  fun clearStale_removesOlderThanCutoffExceptActive() =
+    runBlocking {
+      val now = 10_000_000L
+      val cutoff = now - 1_000L
+      dao.upsert(RemoteKeysEntity("fresh", nextKey = "1", lastUpdated = now))
+      dao.upsert(RemoteKeysEntity("active", nextKey = "1", lastUpdated = 0L))
+      dao.upsert(RemoteKeysEntity("stale", nextKey = "1", lastUpdated = 0L))
+
+      val removed = dao.clearStale(cutoff = cutoff, exceptKey = "active")
+
+      assertThat(removed).isEqualTo(1)
+      assertThat(dao.remoteKeys("stale")).isNull()
+      // Recent key and the excluded active key both survive.
+      assertThat(dao.remoteKeys("fresh")).isNotNull()
+      assertThat(dao.remoteKeys("active")).isNotNull()
+    }
 }

--- a/app/src/test/java/com/burrowsapps/gif/search/data/repository/GifRemoteMediatorTest.kt
+++ b/app/src/test/java/com/burrowsapps/gif/search/data/repository/GifRemoteMediatorTest.kt
@@ -557,4 +557,32 @@ class GifRemoteMediatorTest {
       assertThat(result).isInstanceOf(androidx.paging.RemoteMediator.MediatorResult.Success::class.java)
       assertThat((result as androidx.paging.RemoteMediator.MediatorResult.Success).endOfPaginationReached).isTrue()
     }
+
+  @Test
+  fun append_withAllDuplicateItems_returnsEndOfPagination() =
+    runTest(dispatcher) {
+      // First load caches 2 items with a next cursor.
+      whenever(repository.getTrendingResults(anyOrNull()))
+        .thenReturn(NetworkResult.Success(response(2, "a", next = "10.0")))
+
+      val mediator =
+        GifRemoteMediator(
+          queryKey = "",
+          repository = repository,
+          database = db,
+          dispatcher = dispatcher,
+        )
+      mediator.load(LoadType.REFRESH, emptyState())
+
+      // APPEND returns the SAME items (all duplicates) but a fresh, different cursor.
+      whenever(repository.getTrendingResults("10.0"))
+        .thenReturn(NetworkResult.Success(response(2, "a", next = "20.0")))
+
+      val result = mediator.load(LoadType.APPEND, emptyState())
+
+      // Nothing new was inserted, so pagination must end instead of spinning on fresh cursors.
+      assertThat(result).isInstanceOf(androidx.paging.RemoteMediator.MediatorResult.Success::class.java)
+      assertThat((result as androidx.paging.RemoteMediator.MediatorResult.Success).endOfPaginationReached).isTrue()
+      assertThat(db.queryResultDao().allForQuery("")).hasSize(2)
+    }
 }

--- a/app/src/test/java/com/burrowsapps/gif/search/data/repository/GifRemoteMediatorTest.kt
+++ b/app/src/test/java/com/burrowsapps/gif/search/data/repository/GifRemoteMediatorTest.kt
@@ -12,6 +12,9 @@ import com.burrowsapps.gif.search.data.api.model.MediaDto
 import com.burrowsapps.gif.search.data.api.model.NetworkResult
 import com.burrowsapps.gif.search.data.api.model.ResultDto
 import com.burrowsapps.gif.search.data.db.AppDatabase
+import com.burrowsapps.gif.search.data.db.entity.GifEntity
+import com.burrowsapps.gif.search.data.db.entity.QueryResultEntity
+import com.burrowsapps.gif.search.data.db.entity.RemoteKeysEntity
 import com.burrowsapps.gif.search.ui.giflist.GifImageInfo
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -584,5 +587,69 @@ class GifRemoteMediatorTest {
       assertThat(result).isInstanceOf(androidx.paging.RemoteMediator.MediatorResult.Success::class.java)
       assertThat((result as androidx.paging.RemoteMediator.MediatorResult.Success).endOfPaginationReached).isTrue()
       assertThat(db.queryResultDao().allForQuery("")).hasSize(2)
+    }
+
+  @Test
+  fun refresh_evictsStaleNeverRevisitedQueries_onFirstRefresh() =
+    runTest(dispatcher) {
+      // Seed a search the user never returned to, last fetched at the epoch (far past retention).
+      db.gifDao().upsertAll(listOf(GifEntity("oldtiny", "p", "g", "gp")))
+      db.queryResultDao().insertAll(listOf(QueryResultEntity("oldsearch", "oldtiny", 0)))
+      db.remoteKeysDao().upsert(RemoteKeysEntity("oldsearch", nextKey = "1", lastUpdated = 0L))
+
+      whenever(repository.getTrendingResults(anyOrNull()))
+        .thenReturn(NetworkResult.Success(response(2, "a", next = "10.0")))
+
+      val mediator =
+        GifRemoteMediator(
+          queryKey = "",
+          repository = repository,
+          database = db,
+          dispatcher = dispatcher,
+        )
+      // A fresh mediator qualifies for cleanup on its very first refresh (time arm, since
+      // lastCleanupTime starts at 0L), so a single app-open refresh is enough to evict.
+      mediator.load(LoadType.REFRESH, emptyState())
+
+      // The stale search and its now-orphaned GIF are gone; trending stays.
+      assertThat(db.queryResultDao().allForQuery("oldsearch")).isEmpty()
+      assertThat(db.remoteKeysDao().remoteKeys("oldsearch")).isNull()
+      assertThat(db.gifDao().getById("oldtiny")).isNull()
+      assertThat(db.queryResultDao().allForQuery("")).hasSize(2)
+    }
+
+  @Test
+  fun refresh_throttlesEvictionUntilCleanupInterval() =
+    runTest(dispatcher) {
+      whenever(repository.getTrendingResults(anyOrNull()))
+        .thenReturn(NetworkResult.Success(response(2, "a", next = "10.0")))
+
+      val mediator =
+        GifRemoteMediator(
+          queryKey = "",
+          repository = repository,
+          database = db,
+          dispatcher = dispatcher,
+        )
+      // First refresh runs cleanup and arms the throttle.
+      mediator.load(LoadType.REFRESH, emptyState())
+
+      // Seed stale data AFTER that cleanup. The time arm needs 5 real minutes, which a test run
+      // never reaches, so from here only the count arm (every 5th refresh) can evict it.
+      db.gifDao().upsertAll(listOf(GifEntity("oldtiny", "p", "g", "gp")))
+      db.queryResultDao().insertAll(listOf(QueryResultEntity("oldsearch", "oldtiny", 0)))
+      db.remoteKeysDao().upsert(RemoteKeysEntity("oldsearch", nextKey = "1", lastUpdated = 0L))
+
+      // Refreshes 2-4: neither throttle arm fires, so the stale search must survive. This is what
+      // pins the throttle itself — were cleanup to run on every refresh, these assertions fail.
+      repeat(3) { mediator.load(LoadType.REFRESH, emptyState()) }
+      assertThat(db.queryResultDao().allForQuery("oldsearch")).hasSize(1)
+      assertThat(db.remoteKeysDao().remoteKeys("oldsearch")).isNotNull()
+
+      // The 5th refresh hits the count arm and evicts.
+      mediator.load(LoadType.REFRESH, emptyState())
+      assertThat(db.queryResultDao().allForQuery("oldsearch")).isEmpty()
+      assertThat(db.remoteKeysDao().remoteKeys("oldsearch")).isNull()
+      assertThat(db.gifDao().getById("oldtiny")).isNull()
     }
 }


### PR DESCRIPTION
Performance and cache-hygiene optimizations across the DB layer, image pipeline, and Compose UI.

## Database
- **Bound DB growth with a 7-day retention policy**: new `clearStaleQueries`/`clearStale` DAO queries evict cached results and cursors for searches not revisited within 7 days (the active query is excluded). Orphaned GIF rows are then reclaimed by the existing `deleteOrphanedGifs` pass. Previously every distinct search lingered in the DB forever.
- **Cleanup runs on a fresh mediator's first refresh** (time-arm seeded to fire immediately), then throttles to every 5th refresh / 5 minutes. Since a mediator lives for one query and typically one refresh, gating the first refresh would leave the retention policy essentially unexercised.
- Per-mediator throttle state replaces the previous companion-object maps that grew unbounded per process (from the earlier commit).

## Image pipeline
- **Glide now shares the app OkHttpClient's dispatcher/connection pool but drops its HTTP disk cache** (`cache(null)`): Glide keeps its own disk cache, so the shared 50 MiB OkHttp cache was storing every GIF twice and letting image bytes evict the small Tenor API JSON it exists to retain.
- Dropped a redundant `.signature(ObjectKey(url))` — the URL model already keys the cache.

## Compose UI
- **GIF playback pauses during scroll/fling and while the full-size dialog is open**, resuming at rest — trims the sustained cost of ~20 simultaneous GIF decodes. Implemented as `start()`/`stop()` on the exact `GifDrawable` landscapist renders (no reload, no flicker), driven by a `snapshotFlow` so scroll flips, dialog toggles, and drawable delivery never recompose the visible cells.
- Hoisted shared `ImageOptions` and the per-cell `stringResource` content description out of item composition.

## Tests
- DAO tests for stale-query eviction (fresh/active/stale rows, orphan reclaim).
- Mediator tests pinning both eviction on first refresh and that the throttle defers eviction between cleanup intervals.

Verified locally: `:app:testDebugUnitTest` (fresh run), `:app:lintDebug`, `ktlintCheck` — all passing after rebase onto master (Gradle 9.7.0 / Kotlin 2.4.10).
