### PR TITLE
fix: stop constructing deprecated RenderProcessGoneDetail in tests

### DIFF
--- a/app/src/test/java/com/burrowsapps/gif/search/ui/license/LicenseWebViewClientTest.kt
+++ b/app/src/test/java/com/burrowsapps/gif/search/ui/license/LicenseWebViewClientTest.kt
@@ -16,6 +16,8 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
 
 @RunWith(AndroidJUnit4::class)
 class LicenseWebViewClientTest {
@@ -109,10 +111,11 @@ class LicenseWebViewClientTest {
     assertSame(webView, goneView)
   }
 
+  // RenderProcessGoneDetail's constructor is deprecated - only the framework is meant to build
+  // one - so stub the detail instead of subclassing it.
   private fun renderProcessGoneDetail(): RenderProcessGoneDetail =
-    object : RenderProcessGoneDetail() {
-      override fun didCrash(): Boolean = true
-
-      override fun rendererPriorityAtExit(): Int = WebView.RENDERER_PRIORITY_BOUND
+    mock<RenderProcessGoneDetail> {
+      on { didCrash() } doReturn true
+      on { rendererPriorityAtExit() } doReturn WebView.RENDERER_PRIORITY_BOUND
     }
 }


### PR DESCRIPTION
`RenderProcessGoneDetail`'s constructor is deprecated ("This class should not be constructed by
applications"), and `LicenseWebViewClientTest` was subclassing it to build a fake detail, so every
`:app:compileDebugUnitTestKotlin` printed:

```
w: LicenseWebViewClientTest.kt:113:14 'constructor(): RenderProcessGoneDetail' is deprecated. Deprecated in Java.
```

Stub the detail with `mockito-kotlin` (already a `testImplementation` dependency and the mocking
style used elsewhere in `app/src/test`) instead of subclassing it. Mockito instantiates without
invoking the constructor, so the deprecated API is no longer touched.

`WebViewClient.onRenderProcessGone(WebView, RenderProcessGoneDetail)` itself is not deprecated, so
`LicenseWebViewClient` is unchanged.

### Testing

- `./gradlew :app:testDebugUnitTest --tests "*LicenseWebViewClientTest*" ktlintCheck`
- `./gradlew :app:compileDebugUnitTestKotlin` — no longer emits the deprecation warning
