### PR TITLE
Migrate Room 2.8.4 to androidx.room3 3.0.3

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -169,10 +169,9 @@ dependencies {
   androidTestImplementation(libs.androidx.compose.junit)
 
   // Room Database
-  implementation(libs.androidx.room.runtime)
-  implementation(libs.androidx.room)
-  implementation(libs.androidx.room.paging)
-  ksp(libs.androidx.room.compiler)
+  implementation(libs.androidx.room3.runtime)
+  implementation(libs.androidx.room3.paging)
+  ksp(libs.androidx.room3.compiler)
 
   // Glide
   implementation(libs.landscapist.glide)

--- a/app/src/androidTest/java/com/burrowsapps/gif/search/di/TestDatabaseModule.kt
+++ b/app/src/androidTest/java/com/burrowsapps/gif/search/di/TestDatabaseModule.kt
@@ -1,7 +1,7 @@
 package com.burrowsapps.gif.search.di
 
 import android.content.Context
-import androidx.room.Room
+import androidx.room3.Room
 import com.burrowsapps.gif.search.data.db.AppDatabase
 import com.burrowsapps.gif.search.data.db.dao.GifDao
 import com.burrowsapps.gif.search.data.db.dao.QueryResultDao

--- a/app/src/main/java/com/burrowsapps/gif/search/data/db/AppDatabase.kt
+++ b/app/src/main/java/com/burrowsapps/gif/search/data/db/AppDatabase.kt
@@ -1,7 +1,7 @@
 package com.burrowsapps.gif.search.data.db
 
-import androidx.room.Database
-import androidx.room.RoomDatabase
+import androidx.room3.Database
+import androidx.room3.RoomDatabase
 import com.burrowsapps.gif.search.data.db.dao.GifDao
 import com.burrowsapps.gif.search.data.db.dao.QueryResultDao
 import com.burrowsapps.gif.search.data.db.dao.RemoteKeysDao

--- a/app/src/main/java/com/burrowsapps/gif/search/data/db/dao/GifDao.kt
+++ b/app/src/main/java/com/burrowsapps/gif/search/data/db/dao/GifDao.kt
@@ -1,9 +1,9 @@
 package com.burrowsapps.gif.search.data.db.dao
 
-import androidx.room.Dao
-import androidx.room.Insert
-import androidx.room.OnConflictStrategy
-import androidx.room.Query
+import androidx.room3.Dao
+import androidx.room3.Insert
+import androidx.room3.OnConflictStrategy
+import androidx.room3.Query
 import com.burrowsapps.gif.search.data.db.entity.GifEntity
 
 @Dao

--- a/app/src/main/java/com/burrowsapps/gif/search/data/db/dao/QueryResultDao.kt
+++ b/app/src/main/java/com/burrowsapps/gif/search/data/db/dao/QueryResultDao.kt
@@ -1,15 +1,20 @@
 package com.burrowsapps.gif.search.data.db.dao
 
 import androidx.paging.PagingSource
-import androidx.room.Dao
-import androidx.room.Insert
-import androidx.room.OnConflictStrategy
-import androidx.room.Query
-import androidx.room.RewriteQueriesToDropUnusedColumns
+import androidx.room3.Dao
+import androidx.room3.DaoReturnTypeConverters
+import androidx.room3.Insert
+import androidx.room3.OnConflictStrategy
+import androidx.room3.Query
+import androidx.room3.RewriteQueriesToDropUnusedColumns
+import androidx.room3.paging.PagingSourceDaoReturnTypeConverter
 import com.burrowsapps.gif.search.data.db.entity.QueryResultEntity
 import com.burrowsapps.gif.search.ui.giflist.GifImageInfo
 
+// Room 3 no longer special-cases PagingSource returns: paging support ships as a pluggable
+// return-type converter in room3-paging that has to be declared explicitly.
 @Dao
+@DaoReturnTypeConverters(PagingSourceDaoReturnTypeConverter::class)
 internal interface QueryResultDao {
   // Keep first-seen ordering stable by ignoring duplicates. Returns the inserted row ids (-1 for a
   // row that was ignored as a duplicate) so callers can tell how many new rows actually landed.

--- a/app/src/main/java/com/burrowsapps/gif/search/data/db/dao/RemoteKeysDao.kt
+++ b/app/src/main/java/com/burrowsapps/gif/search/data/db/dao/RemoteKeysDao.kt
@@ -1,9 +1,9 @@
 package com.burrowsapps.gif.search.data.db.dao
 
-import androidx.room.Dao
-import androidx.room.Insert
-import androidx.room.OnConflictStrategy
-import androidx.room.Query
+import androidx.room3.Dao
+import androidx.room3.Insert
+import androidx.room3.OnConflictStrategy
+import androidx.room3.Query
 import com.burrowsapps.gif.search.data.db.entity.RemoteKeysEntity
 
 @Dao

--- a/app/src/main/java/com/burrowsapps/gif/search/data/db/entity/GifEntity.kt
+++ b/app/src/main/java/com/burrowsapps/gif/search/data/db/entity/GifEntity.kt
@@ -1,7 +1,7 @@
 package com.burrowsapps.gif.search.data.db.entity
 
-import androidx.room.Entity
-import androidx.room.PrimaryKey
+import androidx.room3.Entity
+import androidx.room3.PrimaryKey
 
 @Entity(tableName = "gifs")
 internal data class GifEntity(

--- a/app/src/main/java/com/burrowsapps/gif/search/data/db/entity/QueryResultEntity.kt
+++ b/app/src/main/java/com/burrowsapps/gif/search/data/db/entity/QueryResultEntity.kt
@@ -1,8 +1,8 @@
 package com.burrowsapps.gif.search.data.db.entity
 
-import androidx.room.Entity
-import androidx.room.ForeignKey
-import androidx.room.Index
+import androidx.room3.Entity
+import androidx.room3.ForeignKey
+import androidx.room3.Index
 import com.burrowsapps.gif.search.data.db.entity.GifEntity
 
 @Entity(

--- a/app/src/main/java/com/burrowsapps/gif/search/data/db/entity/RemoteKeysEntity.kt
+++ b/app/src/main/java/com/burrowsapps/gif/search/data/db/entity/RemoteKeysEntity.kt
@@ -1,7 +1,7 @@
 package com.burrowsapps.gif.search.data.db.entity
 
-import androidx.room.Entity
-import androidx.room.PrimaryKey
+import androidx.room3.Entity
+import androidx.room3.PrimaryKey
 
 @Entity(tableName = "remote_keys")
 internal data class RemoteKeysEntity(

--- a/app/src/main/java/com/burrowsapps/gif/search/data/repository/GifRemoteMediator.kt
+++ b/app/src/main/java/com/burrowsapps/gif/search/data/repository/GifRemoteMediator.kt
@@ -3,7 +3,7 @@ package com.burrowsapps.gif.search.data.repository
 import androidx.paging.LoadType
 import androidx.paging.PagingState
 import androidx.paging.RemoteMediator
-import androidx.room.withTransaction
+import androidx.room3.withWriteTransaction
 import com.burrowsapps.gif.search.data.api.model.GifResponseDto
 import com.burrowsapps.gif.search.data.api.model.NetworkResult
 import com.burrowsapps.gif.search.data.db.AppDatabase
@@ -165,7 +165,7 @@ internal class GifRemoteMediator(
           )
 
           // Save everything to database in a single transaction for consistency
-          database.withTransaction {
+          database.withWriteTransaction {
             if (items.isNotEmpty()) {
               // Step 1: Upsert GIF entities FIRST (deduplicated by primary key: tinyGifUrl)
               // This ensures GIFs are available before we reference them
@@ -246,7 +246,7 @@ internal class GifRemoteMediator(
                 // the GIFs they pointed at, which deleteOrphanedGifs() below then reclaims.
                 val staleCutoff = System.currentTimeMillis() - STALE_QUERY_RETENTION_MS
                 val evictedRows =
-                  database.withTransaction {
+                  database.withWriteTransaction {
                     val rows = queryResultsDao.clearStaleQueries(staleCutoff, queryKey)
                     remoteKeysDao.clearStale(staleCutoff, queryKey)
                     rows

--- a/app/src/main/java/com/burrowsapps/gif/search/di/DatabaseModule.kt
+++ b/app/src/main/java/com/burrowsapps/gif/search/di/DatabaseModule.kt
@@ -1,8 +1,8 @@
 package com.burrowsapps.gif.search.di
 
 import android.content.Context
-import androidx.room.Room
-import androidx.room.RoomDatabase
+import androidx.room3.Room
+import androidx.room3.RoomDatabase
 import com.burrowsapps.gif.search.data.db.AppDatabase
 import com.burrowsapps.gif.search.data.db.dao.GifDao
 import com.burrowsapps.gif.search.data.db.dao.QueryResultDao

--- a/app/src/test/java/com/burrowsapps/gif/search/data/db/AppDatabaseTest.kt
+++ b/app/src/test/java/com/burrowsapps/gif/search/data/db/AppDatabaseTest.kt
@@ -2,6 +2,7 @@ package com.burrowsapps.gif.search.data.db
 
 import android.database.sqlite.SQLiteConstraintException
 import androidx.room3.Room
+import androidx.room3.withWriteTransaction
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.burrowsapps.gif.search.data.db.entity.GifEntity
@@ -60,5 +61,50 @@ class AppDatabaseTest {
       db.gifDao().clearAll()
       val remain = db.queryResultDao().allForQuery("k")
       assertThat(remain).isEmpty()
+    }
+
+  // Regression coverage for the room3 migration: androidx.room3 dropped withTransaction in favor
+  // of withReadTransaction/withWriteTransaction. GifRemoteMediator's two write sites both switched
+  // to withWriteTransaction; this verifies the replacement genuinely commits writes on success...
+  @Test
+  fun withWriteTransaction_commitsWritesOnSuccess() =
+    runBlocking {
+      db.withWriteTransaction {
+        db.gifDao().upsertAll(listOf(GifEntity("g1", "p1", "u1", "pu1")))
+        db.queryResultDao().insertAll(listOf(QueryResultEntity("k", "g1", 0)))
+      }
+
+      assertThat(db.gifDao().count()).isEqualTo(1)
+      assertThat(db.queryResultDao().allForQuery("k")).hasSize(1)
+    }
+
+  // ...and, critically, that a read-then-write sequence inside one lambda is still atomic: a
+  // failure partway through must roll back every write in that block, not just the one that threw.
+  // This is the same shape as GifRemoteMediator's transactions (e.g. read nextPositionForQuery,
+  // then write inserts) -- if withWriteTransaction silently narrowed to per-statement commits
+  // instead of one real transaction, this test would catch it as a partial write surviving.
+  @Test
+  fun withWriteTransaction_rollsBackAllWritesOnFailure() =
+    runBlocking {
+      var threw = false
+      try {
+        db.withWriteTransaction {
+          // Write #1
+          db.gifDao().upsertAll(listOf(GifEntity("g1", "p1", "u1", "pu1")))
+          // Read inside the same transaction, consistent with the write above
+          val countAfterWrite = db.gifDao().count()
+          assertThat(countAfterWrite).isEqualTo(1)
+          // Write #2, then fail before the transaction can commit
+          db.queryResultDao().insertAll(listOf(QueryResultEntity("k", "g1", 0)))
+          throw IllegalStateException("boom")
+        }
+      } catch (e: IllegalStateException) {
+        threw = true
+      }
+
+      assertThat(threw).isTrue()
+      // Both writes -- not just the one nearest the throw -- must be rolled back.
+      assertThat(db.gifDao().count()).isEqualTo(0)
+      assertThat(db.queryResultDao().allForQuery("k")).isEmpty()
     }
 }

--- a/app/src/test/java/com/burrowsapps/gif/search/data/db/AppDatabaseTest.kt
+++ b/app/src/test/java/com/burrowsapps/gif/search/data/db/AppDatabaseTest.kt
@@ -1,7 +1,7 @@
 package com.burrowsapps.gif.search.data.db
 
 import android.database.sqlite.SQLiteConstraintException
-import androidx.room.Room
+import androidx.room3.Room
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.burrowsapps.gif.search.data.db.entity.GifEntity

--- a/app/src/test/java/com/burrowsapps/gif/search/data/db/dao/GifDaoTest.kt
+++ b/app/src/test/java/com/burrowsapps/gif/search/data/db/dao/GifDaoTest.kt
@@ -1,6 +1,6 @@
 package com.burrowsapps.gif.search.data.db.dao
 
-import androidx.room.Room
+import androidx.room3.Room
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.burrowsapps.gif.search.data.db.AppDatabase

--- a/app/src/test/java/com/burrowsapps/gif/search/data/db/dao/QueryResultDaoTest.kt
+++ b/app/src/test/java/com/burrowsapps/gif/search/data/db/dao/QueryResultDaoTest.kt
@@ -1,6 +1,6 @@
 package com.burrowsapps.gif.search.data.db.dao
 
-import androidx.room.Room
+import androidx.room3.Room
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.burrowsapps.gif.search.data.db.AppDatabase

--- a/app/src/test/java/com/burrowsapps/gif/search/data/db/dao/QueryResultDaoTest.kt
+++ b/app/src/test/java/com/burrowsapps/gif/search/data/db/dao/QueryResultDaoTest.kt
@@ -1,5 +1,6 @@
 package com.burrowsapps.gif.search.data.db.dao
 
+import androidx.paging.PagingSource
 import androidx.room3.Room
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -7,6 +8,7 @@ import com.burrowsapps.gif.search.data.db.AppDatabase
 import com.burrowsapps.gif.search.data.db.entity.GifEntity
 import com.burrowsapps.gif.search.data.db.entity.QueryResultEntity
 import com.burrowsapps.gif.search.data.db.entity.RemoteKeysEntity
+import com.burrowsapps.gif.search.ui.giflist.GifImageInfo
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.runBlocking
 import org.junit.After
@@ -175,5 +177,57 @@ class QueryResultDaoTest {
       assertThat(dao.allForQuery("")).hasSize(1)
       assertThat(dao.allForQuery("cats")).hasSize(1)
       assertThat(db.gifDao().count()).isEqualTo(1)
+    }
+
+  // Regression coverage for the room3 migration: room3-compiler no longer special-cases
+  // PagingSource DAO returns on its own. Support only exists because QueryResultDao carries
+  // @DaoReturnTypeConverters(PagingSourceDaoReturnTypeConverter::class) at the @Dao (class) level.
+  // If that annotation were missing, misplaced (e.g. on the function instead of the interface), or
+  // silently ignored by the compiler, pagingSource() would either fail to compile or -- worse --
+  // compile but return a broken/empty PagingSource at runtime, which is exactly the kind of failure
+  // that would slip past code review and only surface as an empty results grid in production.
+  @Test
+  fun pagingSource_load_returnsInsertedItemsInOrder() =
+    runBlocking {
+      val gifs =
+        listOf(
+          GifEntity("tiny1", "preview1", "gif1", "gifPrev1"),
+          GifEntity("tiny2", "preview2", "gif2", "gifPrev2"),
+        )
+      db.gifDao().upsertAll(gifs)
+
+      val query = "cats"
+      dao.insertAll(
+        listOf(
+          QueryResultEntity(query, "tiny1", 0),
+          QueryResultEntity(query, "tiny2", 1),
+        ),
+      )
+
+      val pagingSource = dao.pagingSource(query)
+      val result =
+        pagingSource.load(
+          PagingSource.LoadParams.Refresh(key = null, loadSize = 10, placeholdersEnabled = false),
+        )
+
+      assertThat(result).isInstanceOf(PagingSource.LoadResult.Page::class.java)
+      val page = result as PagingSource.LoadResult.Page<Int, GifImageInfo>
+      assertThat(page.data.map { it.tinyGifUrl }).containsExactly("tiny1", "tiny2").inOrder()
+    }
+
+  // Edge case: a query with no cached rows should yield a valid, empty page rather than throwing
+  // or returning null/Invalid -- callers (Paging3) rely on that contract to render an empty list.
+  @Test
+  fun pagingSource_load_withNoMatchingRows_returnsEmptyPage() =
+    runBlocking {
+      val pagingSource = dao.pagingSource("no-such-query")
+      val result =
+        pagingSource.load(
+          PagingSource.LoadParams.Refresh(key = null, loadSize = 10, placeholdersEnabled = false),
+        )
+
+      assertThat(result).isInstanceOf(PagingSource.LoadResult.Page::class.java)
+      val page = result as PagingSource.LoadResult.Page<Int, GifImageInfo>
+      assertThat(page.data).isEmpty()
     }
 }

--- a/app/src/test/java/com/burrowsapps/gif/search/data/db/dao/RemoteKeysDaoTest.kt
+++ b/app/src/test/java/com/burrowsapps/gif/search/data/db/dao/RemoteKeysDaoTest.kt
@@ -1,6 +1,6 @@
 package com.burrowsapps.gif.search.data.db.dao
 
-import androidx.room.Room
+import androidx.room3.Room
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.burrowsapps.gif.search.data.db.AppDatabase

--- a/app/src/test/java/com/burrowsapps/gif/search/data/repository/GifRemoteMediatorTest.kt
+++ b/app/src/test/java/com/burrowsapps/gif/search/data/repository/GifRemoteMediatorTest.kt
@@ -3,7 +3,7 @@ package com.burrowsapps.gif.search.data.repository
 import androidx.paging.LoadType
 import androidx.paging.PagingConfig
 import androidx.paging.PagingState
-import androidx.room.Room
+import androidx.room3.Room
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.burrowsapps.gif.search.data.api.model.DataDto

--- a/app/src/test/java/com/burrowsapps/gif/search/ui/giflist/GifViewModelTest.kt
+++ b/app/src/test/java/com/burrowsapps/gif/search/ui/giflist/GifViewModelTest.kt
@@ -1,6 +1,6 @@
 package com.burrowsapps.gif.search.ui.giflist
 
-import androidx.room.Room
+import androidx.room3.Room
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.burrowsapps.gif.search.data.db.AppDatabase

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ glide = "5.0.9"
 leakcanary = "2.14"
 moshi = "1.15.2"
 robolectric = "4.17-beta-4"
-room = "2.8.4"
+room3 = "3.0.3"
 # build
 sdk = "37"
 # signing
@@ -38,10 +38,9 @@ androidx-compose-uitoolingpreview = { module = "androidx.compose.ui:ui-tooling-p
 androidx-core = { module = "androidx.core:core-ktx", version = "1.19.0" }
 androidx-hilt-compose = { module = "androidx.hilt:hilt-navigation-compose", version = "1.4.0" }
 androidx-paging-compose = { module = "androidx.paging:paging-compose", version = "3.5.1" }
-androidx-room = { module = "androidx.room:room-ktx", version.ref = "room" }
-androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
-androidx-room-paging = { module = "androidx.room:room-paging", version.ref = "room" }
-androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
+androidx-room3-compiler = { module = "androidx.room3:room3-compiler", version.ref = "room3" }
+androidx-room3-paging = { module = "androidx.room3:room3-paging", version.ref = "room3" }
+androidx-room3-runtime = { module = "androidx.room3:room3-runtime", version.ref = "room3" }
 androidx-test-annotation = { module = "androidx.test:annotation", version = "1.0.1" }
 androidx-test-core = { module = "androidx.test:core-ktx", version = "1.7.0" }
 androidx-test-junit = { module = "androidx.test.ext:junit-ktx", version = "1.3.0" }


### PR DESCRIPTION
Migrates the app from Room 2.8.4 (`androidx.room`) to Room 3.0.3 (`androidx.room3`).

## What changed

- **Version catalog**: version key `room = "2.8.4"` -> `room3 = "3.0.3"`; aliases renamed to
  `androidx-room3-{runtime,paging,compiler}` pointing at `androidx.room3:room3-*`. The
  `room-ktx` entry is **dropped, not renamed** — `androidx.room3:room3-ktx` does not exist; the
  KTX surface is folded into `room3-runtime`.
- **`app/build.gradle.kts`**: three Room dependencies instead of four (runtime, paging, `ksp`
  compiler).
- **Sources**: `androidx.room.*` -> `androidx.room3.*` across 16 files (9 main, 6 unit test,
  1 androidTest). Schema is untouched: db name `gif-db`, `version = 2`, `exportSchema = false`,
  `fallbackToDestructiveMigration(false)`.

## API deltas

- **`withTransaction` (room-ktx) has no room3 counterpart.** `androidx.room3.RoomDatabaseKt`
  exposes `withReadTransaction` / `withWriteTransaction` (plus the connection-level
  `Transactor.withTransaction(SQLiteTransactionType, block)`), so both `GifRemoteMediator` call
  sites — which both write — now use `androidx.room3.withWriteTransaction`. That is
  IMMEDIATE-style, i.e. strictly safer than the previous deferred behavior for write blocks. The
  lambda bodies are unchanged.
- **`PagingSource` returns are no longer special-cased by the compiler.** room3-compiler fails
  with "Not sure how to convert the query result to this function's return type ... Did you
  forget to provide a `@DaoReturnTypeConverter`". Paging support now ships as a pluggable
  converter, `androidx.room3.paging.PagingSourceDaoReturnTypeConverter`, which has to be declared
  explicitly, so `QueryResultDao` carries
  `@DaoReturnTypeConverters(PagingSourceDaoReturnTypeConverter::class)`. Generated
  `QueryResultDao_Impl` confirms it is wired through.
- **`setJournalMode` survived (Plan A).** `androidx.room3.RoomDatabase.Builder.setJournalMode(
  RoomDatabase.JournalMode)` and `JournalMode.{AUTOMATIC,TRUNCATE,WRITE_AHEAD_LOGGING}` are still
  present in room3-runtime 3.0.3 (verified against the published
  `room3-runtime-android-3.0.3.aar`, and it compiles), so `DatabaseModule` keeps
  `.setJournalMode(RoomDatabase.JournalMode.WRITE_AHEAD_LOGGING)` verbatim. No behavior change,
  and no `room3-sqlite-wrapper` was needed.
- **Builder overloads unchanged.** The `Class<T>`-based `Room.databaseBuilder(context,
  AppDatabase::class.java, "gif-db")` and `Room.inMemoryDatabaseBuilder(context,
  AppDatabase::class.java)` overloads still exist in room3 alongside the newer
  `Function0`-based ones, so no DI or test call shape changed.

## Deliberately not done

- No `androidx.room3:room3-sqlite-wrapper`: the repo has zero references to `SupportSQLite*`,
  `androidx.sqlite`, `openHelper`, `runInTransaction` or `InvalidationTracker`, so the
  compatibility bridge would be dead weight.
- No `androidx.room3` Gradle plugin: its value is schema export for reproducible schemas and
  auto-migrations; this database sets `exportSchema = false`, has no `@AutoMigration`, and falls
  back destructively on a fully re-fetchable network cache. Worth revisiting separately.
- No Renovate config change: no `androidx.room:*` coordinate remains anywhere in the repo, so
  Renovate simply tracks `androidx.room3:*` from here on.

## New tests

Two migration risk areas had zero prior coverage; this PR adds four unit tests for them
(`app/src/test/.../data/db/dao/QueryResultDaoTest.kt`, `app/src/test/.../data/db/AppDatabaseTest.kt`):

- `pagingSource_load_returnsInsertedItemsInOrder` / `pagingSource_load_withNoMatchingRows_returnsEmptyPage`
  — the first tests anywhere in the repo to actually invoke the generated `PagingSource`. Until now
  `@DaoReturnTypeConverters(PagingSourceDaoReturnTypeConverter::class)` was only proven to *compile*;
  these load a page through it and assert row content, ordering and the empty-result shape, so the
  converter is verified at runtime.
- `withWriteTransaction_commitsWritesOnSuccess` / `withWriteTransaction_rollsBackAllWritesOnFailure`
  — assert commit-on-success and, more importantly, that a failure inside the block rolls back
  *every* write in it. This is the atomicity guarantee `GifRemoteMediator` depends on and that the
  removed `androidx.room.withTransaction` used to provide.

Unit tests are now **113** (109 baseline + these 4), 0 failures.

## Security findings — handled separately

A security review of this branch produced two LOW findings, both **pre-existing** and neither a
migration defect. They are deliberately kept out of this PR so it stays a pure migration:

- **S2** — `settings.gradle.kts` filters `google()` with an *inclusive* `mavenContent`, while the
  following `mavenCentral()` is unfiltered, so an `androidx.*` coordinate Google Maven cannot serve
  can fall through to Maven Central. Fixed in its own PR via `exclusiveContent` on `androidx`.
- **S1** — the repo has no dependency verification metadata / lockfile, so nothing pins artifact
  checksums. Consciously **deferred to a separate PR**: generating
  `gradle/verification-metadata.xml` touches every dependency in the build and would swamp this
  diff. Not a blocker here.

## Verification

Run locally against this branch:

- `./gradlew ktlintCheck assembleDebug lintDebug testDebug -s --continue` — green
  (113 unit tests, 0 failures; Robolectric drives the room3 stack fine).
- `./gradlew assembleRelease -s` — green (R8 smoke).
- `grep -rn "androidx\.room[^3]"` over `app/src`, `gradle/`, `*.kts`, `*.json` — no hits.
- `:app:dependencies --configuration debugRuntimeClasspath` resolves only `androidx.room3:*:3.0.3`.

Instrumentation tests (`connectedDebugAndroidTest`) were **not** run locally — no emulator or
device was available in this environment — so that gate is delegated to the CI Instrumentation
Tests job on this PR.

One note for reviewers: `:app:lintAnalyzeDebugAndroidTest` crashed once with an internal K2/UAST
error ("Error while resolving FirRegularClassImpl from RAW_FIR to COMPILER_REQUIRED_ANNOTATIONS")
on `TestApiConfigModule.kt`, a file untouched by this change. It does not reproduce — re-running
the task on this branch passes, and `--rerun-tasks` on the base commit also passes — so it is a
lint infrastructure flake, not migration fallout.

