### PR TITLE
Restrict androidx to Google's Maven repo via exclusiveContent

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,10 +1,18 @@
 pluginManagement {
   repositories {
-    google {
-      mavenContent {
+    exclusiveContent {
+      // androidx is served ONLY by Google's Maven repo, so an androidx coordinate that
+      // dl.google.com cannot serve fails instead of falling through to Maven Central.
+      forRepository {
+        google {
+          mavenContent {
+            includeGroupAndSubgroups("com.android")
+            includeGroupAndSubgroups("com.google")
+          }
+        }
+      }
+      filter {
         includeGroupAndSubgroups("androidx")
-        includeGroupAndSubgroups("com.android")
-        includeGroupAndSubgroups("com.google")
       }
     }
     mavenCentral()
@@ -16,11 +24,19 @@ dependencyResolutionManagement {
   repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
 
   repositories {
-    google {
-      mavenContent {
+    exclusiveContent {
+      // androidx is served ONLY by Google's Maven repo, so an androidx coordinate that
+      // dl.google.com cannot serve fails instead of falling through to Maven Central.
+      forRepository {
+        google {
+          mavenContent {
+            includeGroupAndSubgroups("com.android")
+            includeGroupAndSubgroups("com.google")
+          }
+        }
+      }
+      filter {
         includeGroupAndSubgroups("androidx")
-        includeGroupAndSubgroups("com.android")
-        includeGroupAndSubgroups("com.google")
       }
     }
     mavenCentral()


### PR DESCRIPTION
Makes `androidx` resolvable **only** from Google's Maven repo, closing a dependency-confusion
fall-through in `settings.gradle.kts`. Pre-existing issue, unrelated to any feature work — split
out of #1362 so it is reviewable on its own.

## The problem

Both `pluginManagement.repositories` and `dependencyResolutionManagement.repositories` filtered
`google()` with an **inclusive** `mavenContent`:

```kotlin
google {
  mavenContent {
    includeGroupAndSubgroups("androidx")
    includeGroupAndSubgroups("com.android")
    includeGroupAndSubgroups("com.google")
  }
}
mavenCentral()   // no filter
```

An inclusive filter only constrains what `google()` is *allowed to serve*. It does nothing to stop
an `androidx.*` coordinate that `dl.google.com` cannot serve from falling through to the
completely unfiltered `mavenCentral()` — where the `androidx` namespace is not Google-controlled
and anyone can claim an unused group.

This is not theoretical. Resolving a nonexistent `androidx.*` coordinate against the old config
(isolated `GRADLE_USER_HOME`, so nothing cached) searched **both** repositories:

```
> Could not find androidx.definitelynotreal:nope:1.0.0.
  Searched in the following locations:
    - https://dl.google.com/dl/android/maven2/androidx/definitelynotreal/nope/1.0.0/nope-1.0.0.pom
    - https://repo.maven.apache.org/maven2/androidx/definitelynotreal/nope/1.0.0/nope-1.0.0.pom
```

## The fix

Wrap `google()` in `exclusiveContent` with a filter on `androidx`, in both repository blocks.
`exclusiveContent` is the *exclusive* form: it tells Gradle this repository is the only one that
may ever serve the matched groups. Same probe after the change:

```
> Could not find androidx.definitelynotreal:nope:1.0.0.
  Searched in the following locations:
    - https://dl.google.com/dl/android/maven2/androidx/definitelynotreal/nope/1.0.0/nope-1.0.0.pom
```

Maven Central is no longer consulted for `androidx`.

## Deliberately narrowed to `androidx` only

`com.android` and `com.google` keep the existing **inclusive** `mavenContent` filter and were
**not** made exclusive. That is intentional, not an oversight — several `com.google.*` groups this
build depends on are published to **Maven Central, not Google Maven**, so making the group
exclusive to `google()` would break resolution outright:

- `com.google.dagger:hilt-android` / `dagger` / `hilt-android-testing` (Hilt)
- `com.google.truth:truth`
- `com.google.code.findbugs:jsr305`
- the `com.google.devtools.ksp` plugin and `symbol-processing-api`

`com.android` is Google-Maven-only in practice, but it is left alone here to keep this change
minimal and focused on the group that actually has the fall-through exposure. Note the filters
compose: the `exclusiveContent` filter and the repository's own `mavenContent` are additive, so
`google()` still serves `com.android` and `com.google` exactly as before.

## Verification

All run on this branch:

- `./gradlew ktlintCheck assembleDebug lintDebug testDebug assembleRelease -s --continue` —
  **BUILD SUCCESSFUL**, 109 unit tests, 0 failures. `lint.warningsAsErrors = true` and
  `checkDependencies = true` are in force.
- `:app:dependencies` for `debugRuntimeClasspath`, `debugUnitTestRuntimeClasspath`,
  `debugAndroidTestRuntimeClasspath` and `releaseRuntimeClasspath` is **byte-identical** before and
  after the change, including a full `--refresh-dependencies` pass so no cached
  module-to-repository association could mask a break. 341 distinct `androidx` coordinates still
  resolve; Hilt, Truth and jsr305 still resolve from Maven Central; KSP still runs (it processes
  Room and Hilt in the build above).
- Independently confirmed in a throwaway project with an isolated `GRADLE_USER_HOME` that under the
  new config `com.android.tools.build:gradle`, `androidx.room3:room3-runtime`, `com.google.truth:truth`,
  `com.google.code.findbugs:jsr305`, `com.google.dagger:hilt-android` and
  `com.google.devtools.ksp:symbol-processing-api` all still resolve.

No dependency, version or lockfile changes — the resolved graph is unchanged by design. This only
narrows *where* Gradle is permitted to look.

## Not in scope

Artifact checksum pinning (a committed `gradle/verification-metadata.xml`) is the other half of
supply-chain hardening and is **consciously deferred to a separate PR** — it touches every
dependency in the build and would swamp this diff.
